### PR TITLE
Scramble nonce into plain text

### DIFF
--- a/handlers/api/callback.go
+++ b/handlers/api/callback.go
@@ -39,7 +39,7 @@ func CallbackGet(c *fiber.Ctx) error {
 	if redirectCode != "codeberg" && redirectCode != "gitlab" {
 		service = "github"
 		// Decode the string so we get our actual information back.
-		code, err := utils.DecodePreparedText(redirectCode, utils.AEAD_OAUTH)
+		code, err := utils.DecodePreparedText(redirectCode, utils.AEAD_OAUTH, config.ScrambleConfig)
 		if err != nil {
 			log.Println("Error: Couldn't decode our prepared text.")
 			return c.Next()

--- a/handlers/oauthProvider/access_token.go
+++ b/handlers/oauthProvider/access_token.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 
 	"userstyles.world/models"
+	"userstyles.world/modules/config"
 	"userstyles.world/utils"
 )
 
@@ -34,7 +35,7 @@ func TokenPost(c *fiber.Ctx) error {
 		return errorMessage(c, 400, "Incorrect client_secret specified")
 	}
 
-	unsealedText, err := utils.DecodePreparedText(tCode, utils.AEAD_OAUTHP)
+	unsealedText, err := utils.DecodePreparedText(tCode, utils.AEAD_OAUTHP, config.ScrambleConfig)
 	if err != nil {
 		log.Println("Error: Couldn't unseal JWT Token:", err.Error())
 		return errorMessage(c, 500, "JWT Token error, please notify the admins.")

--- a/handlers/oauthProvider/authorize.go
+++ b/handlers/oauthProvider/authorize.go
@@ -11,6 +11,7 @@ import (
 
 	jwtware "userstyles.world/handlers/jwt"
 	"userstyles.world/models"
+	"userstyles.world/modules/config"
 	"userstyles.world/utils"
 )
 
@@ -34,7 +35,7 @@ func redirectFunction(c *fiber.Ctx, state, redirectURI string) error {
 		return errorMessage(c, 500, "JWT Token error, please notify the admins.")
 	}
 
-	returnCode := "?code=" + utils.PrepareText(jwt, utils.AEAD_OAUTHP)
+	returnCode := "?code=" + utils.PrepareText(jwt, utils.AEAD_OAUTHP, config.ScrambleConfig)
 	if state != "" {
 		returnCode += "&state=" + state
 	}
@@ -97,7 +98,7 @@ func AuthorizeGet(c *fiber.Ctx) error {
 	arguments := fiber.Map{
 		"User":        u,
 		"OAuth":       OAuth,
-		"SecureToken": utils.PrepareText(jwt, utils.AEAD_OAUTHP),
+		"SecureToken": utils.PrepareText(jwt, utils.AEAD_OAUTHP, config.ScrambleConfig),
 	}
 	for _, v := range OAuth.Scopes {
 		arguments["Scope_"+v] = true
@@ -115,7 +116,7 @@ func AuthPost(c *fiber.Ctx) error {
 		return errorMessage(c, 400, "Incorrect oauthID specified")
 	}
 
-	unsealedText, err := utils.DecodePreparedText(secureToken, utils.AEAD_OAUTHP)
+	unsealedText, err := utils.DecodePreparedText(secureToken, utils.AEAD_OAUTHP, config.ScrambleConfig)
 	if err != nil {
 		log.Println("Error: Couldn't unseal JWT Token:", err.Error())
 		return errorMessage(c, 500, "JWT Token error, please notify the admins.")

--- a/handlers/oauthProvider/authorize_style.go
+++ b/handlers/oauthProvider/authorize_style.go
@@ -11,6 +11,7 @@ import (
 
 	jwtware "userstyles.world/handlers/jwt"
 	"userstyles.world/models"
+	"userstyles.world/modules/config"
 	"userstyles.world/utils"
 )
 
@@ -45,7 +46,7 @@ func OAuthStyleGet(c *fiber.Ctx) error {
 		log.Println("Error: Couldn't make a JWT Token due to:", err.Error())
 		return errorMessage(c, 500, "Couldn't make JWT Token, please notify the admins.")
 	}
-	secureToken := utils.PrepareText(jwt, utils.AEAD_OAUTHP)
+	secureToken := utils.PrepareText(jwt, utils.AEAD_OAUTHP, config.ScrambleConfig)
 
 	styles, err := models.GetStylesByUser(u.Username)
 	if err != nil {
@@ -81,7 +82,7 @@ func OAuthStylePost(c *fiber.Ctx) error {
 		return errorMessage(c, 400, "Incorrect oauthID specified")
 	}
 
-	unsealedText, err := utils.DecodePreparedText(secureToken, utils.AEAD_OAUTHP)
+	unsealedText, err := utils.DecodePreparedText(secureToken, utils.AEAD_OAUTHP, config.ScrambleConfig)
 	if err != nil {
 		log.Println("Error: Couldn't unseal JWT Token:", err.Error())
 		return errorMessage(c, 500, "JWT Token error, please notify the admins.")
@@ -128,7 +129,7 @@ func OAuthStylePost(c *fiber.Ctx) error {
 		return errorMessage(c, 500, "JWT Token error, please notify the admins.")
 	}
 
-	returnCode := "?code=" + utils.PrepareText(jwt, utils.AEAD_OAUTHP)
+	returnCode := "?code=" + utils.PrepareText(jwt, utils.AEAD_OAUTHP, config.ScrambleConfig)
 	returnCode += "&style_id=" + styleID
 	if state != "" {
 		returnCode += "&state=" + state
@@ -146,7 +147,7 @@ func OAuthStyleNewPost(c *fiber.Ctx) error {
 		return errorMessage(c, 400, "Incorrect oauthID specified")
 	}
 
-	unsealedText, err := utils.DecodePreparedText(secureToken, utils.AEAD_OAUTHP)
+	unsealedText, err := utils.DecodePreparedText(secureToken, utils.AEAD_OAUTHP, config.ScrambleConfig)
 	if err != nil {
 		log.Println("Error: Couldn't unseal JWT Token:", err.Error())
 		return errorMessage(c, 500, "JWT Token error, please notify the admins.")

--- a/handlers/style/add.go
+++ b/handlers/style/add.go
@@ -16,6 +16,7 @@ import (
 
 	jwtware "userstyles.world/handlers/jwt"
 	"userstyles.world/models"
+	"userstyles.world/modules/config"
 	"userstyles.world/modules/database"
 	"userstyles.world/modules/images"
 	"userstyles.world/search"
@@ -146,7 +147,7 @@ func handleAPIStyle(c *fiber.Ctx, secureToken, oauthID, styleID string, style *m
 			})
 	}
 
-	unsealedText, err := utils.DecodePreparedText(secureToken, utils.AEAD_OAUTHP)
+	unsealedText, err := utils.DecodePreparedText(secureToken, utils.AEAD_OAUTHP, config.ScrambleConfig)
 	if err != nil {
 		log.Println("Error: Couldn't unseal JWT Token:", err.Error())
 		return c.Status(500).
@@ -205,7 +206,7 @@ func handleAPIStyle(c *fiber.Ctx, secureToken, oauthID, styleID string, style *m
 			})
 	}
 
-	returnCode := "?code=" + utils.PrepareText(jwt, utils.AEAD_OAUTHP)
+	returnCode := "?code=" + utils.PrepareText(jwt, utils.AEAD_OAUTHP, config.ScrambleConfig)
 	returnCode += "&style_id=" + styleID
 	if state != "" {
 		returnCode += "&state=" + state

--- a/handlers/user/register.go
+++ b/handlers/user/register.go
@@ -10,6 +10,7 @@ import (
 
 	"userstyles.world/handlers/jwt"
 	"userstyles.world/models"
+	"userstyles.world/modules/config"
 	"userstyles.world/utils"
 )
 
@@ -57,7 +58,7 @@ func RegisterPost(c *fiber.Ctx) error {
 			})
 	}
 
-	link := c.BaseURL() + "/verify/" + utils.PrepareText(token, utils.AEAD_CRYPTO)
+	link := c.BaseURL() + "/verify/" + utils.PrepareText(token, utils.AEAD_CRYPTO, config.ScrambleConfig)
 
 	partPlain := utils.NewPart().
 		SetBody("Verify your UserStyles.world account by clicking the link below.\n" +

--- a/handlers/user/reset.go
+++ b/handlers/user/reset.go
@@ -10,6 +10,7 @@ import (
 
 	jwtware "userstyles.world/handlers/jwt"
 	"userstyles.world/models"
+	"userstyles.world/modules/config"
 	"userstyles.world/modules/database"
 	"userstyles.world/utils"
 )
@@ -39,7 +40,7 @@ func ResetGet(c *fiber.Ctx) error {
 		return renderError
 	}
 
-	_, err := utils.DecodePreparedText(key, utils.AEAD_CRYPTO)
+	_, err := utils.DecodePreparedText(key, utils.AEAD_CRYPTO, config.ScrambleConfig)
 	if err != nil {
 		log.Printf("Couldn't decode key due to: %s\n", err.Error())
 		return renderError
@@ -71,7 +72,7 @@ func ResetPost(c *fiber.Ctx) error {
 		return renderError
 	}
 
-	unSealedText, err := utils.DecodePreparedText(key, utils.AEAD_CRYPTO)
+	unSealedText, err := utils.DecodePreparedText(key, utils.AEAD_CRYPTO, config.ScrambleConfig)
 	if err != nil {
 		log.Printf("Couldn't decode key due to: %s\n", err.Error())
 		return renderError
@@ -154,7 +155,7 @@ func RecoverPost(c *fiber.Ctx) error {
 			})
 	}
 
-	link := c.BaseURL() + "/reset/" + utils.PrepareText(jwt, utils.AEAD_CRYPTO)
+	link := c.BaseURL() + "/reset/" + utils.PrepareText(jwt, utils.AEAD_CRYPTO, config.ScrambleConfig)
 
 	partPlain := utils.NewPart().
 		SetBody("We have received a request to reset the password for your UserStyles.world account.\n\n" +

--- a/handlers/user/verify.go
+++ b/handlers/user/verify.go
@@ -8,6 +8,7 @@ import (
 
 	jwtware "userstyles.world/handlers/jwt"
 	"userstyles.world/models"
+	"userstyles.world/modules/config"
 	"userstyles.world/modules/database"
 	"userstyles.world/utils"
 )
@@ -28,7 +29,7 @@ func VerifyGet(c *fiber.Ctx) error {
 		})
 	}
 
-	unSealedText, err := utils.DecodePreparedText(base64Key, utils.AEAD_CRYPTO)
+	unSealedText, err := utils.DecodePreparedText(base64Key, utils.AEAD_CRYPTO, config.ScrambleConfig)
 	if err != nil {
 		log.Printf("Couldn't decode key due to: %s\n", err.Error())
 		return c.Render("err", fiber.Map{

--- a/modules/config/config.go
+++ b/modules/config/config.go
@@ -3,7 +3,13 @@ package config
 import (
 	"fmt"
 	"os"
+	"strconv"
 )
+
+type NonceScramblingConfig struct {
+	StepSize       int
+	BytesPerInsert int
+}
 
 var (
 	PORT                   = getEnv("PORT", ":3000")
@@ -32,7 +38,24 @@ var (
 
 	// Production is used for various "feature flags".
 	Production = DB != "dev.db"
+
+	ScrambleConfig = &NonceScramblingConfig{
+		StepSize:       getEnvInt("NONCE_SCRAMBLE_STEP", 2),
+		BytesPerInsert: getEnvInt("NONCE_SCRAMBLE_BYTES_PER_INSERT", 3),
+	}
 )
+
+func getEnvInt(name string, defaultValue int) int {
+	envValue := getEnv(name, "__NOT_FOUND!")
+	if envValue == "__NOT_FOUND!" {
+		return defaultValue
+	}
+	if envInt, err := strconv.Atoi(envValue); err != nil {
+		return defaultValue
+	} else {
+		return envInt
+	}
+}
 
 func getEnv(name, fallback string) string {
 	if val, set := os.LookupEnv(name); set {

--- a/modules/errors/errors.go
+++ b/modules/errors/errors.go
@@ -86,9 +86,16 @@ var (
 
 	// ErrOnlyRemovedStyle errors that this function only allows to remove style kind.
 	ErrOnlyRemovedStyle = errors.New("only remove style kind is allowed")
+
+	errTextTooShort = errors.New("text is too short")
 )
 
 // UnexpectedSigningMethod errors that a unexpected jwt signing method was used.
 func UnexpectedSigningMethod(message string) error {
 	return fmt.Errorf("%w=%s", errUnexpectedSigningMethod, message)
+}
+
+// TexTooShort errors that the nonce was larger than the actual text.
+func TexTooShort(nonceSize, textSize int) error {
+	return fmt.Errorf("%w nonce(%d) > text(%d)", errTextTooShort, nonceSize, textSize)
 }

--- a/utils/chacha20poly1305_test.go
+++ b/utils/chacha20poly1305_test.go
@@ -201,6 +201,35 @@ func TestNonceDescramblingInsaneConfig(t *testing.T) {
 	}
 }
 
+func TestNonceDescramblingPerfectStop(t *testing.T) {
+	t.Parallel()
+
+	nonce := "1234567890"
+	text := "abcdefghijklmnopqr"
+
+	dest := ScrambleNonce(UnsafeBytes(nonce), UnsafeBytes(text), 3, 1)
+
+	if len(dest) == len(nonce)+len(text) && string(dest) != "1abc2def3ghi4jkl5mno6pqr7890" {
+		t.Error("Nonce descrambling failed.")
+	}
+
+	// In production we know the Nonce of a specific hash, due to,
+	// that AEAD is used. Which used a hard-coded length.
+	descrambledNonce, descrambledText, err := DescrambleNonce(dest, len(nonce), 3, 1)
+
+	if err != nil {
+		t.Error("Couldn't descramble, errored:", err)
+	}
+
+	if string(descrambledNonce) != nonce {
+		t.Error("Couldn't descramble nonce")
+	}
+
+	if string(descrambledText) != text {
+		t.Error("Couldn't descramble text")
+	}
+}
+
 func TestNonceDescramblingWithOverflow(t *testing.T) {
 	t.Parallel()
 

--- a/utils/chacha20poly1305_test.go
+++ b/utils/chacha20poly1305_test.go
@@ -172,6 +172,35 @@ func TestNonceDescrambling(t *testing.T) {
 	}
 }
 
+func TestNonceDescramblingInsaneConfig(t *testing.T) {
+	t.Parallel()
+
+	nonce := "123132131312312312312312312312313123123123123123"
+	text := "HellloBeautfikfuldasa"
+
+	dest := ScrambleNonce(UnsafeBytes(nonce), UnsafeBytes(text), 9, 20)
+
+	if len(dest) == len(nonce)+len(text) && string(dest) != "12313213131231231231HellloBea23123123123131231231utfikfuld23123123asa" {
+		t.Error("Nonce descrambling failed.")
+	}
+
+	// In production we know the Nonce of a specific hash, due to,
+	// that AEAD is used. Which used a hard-coded length.
+	descrambledNonce, descrambledText, err := DescrambleNonce(dest, len(nonce), 9, 20)
+
+	if err != nil {
+		t.Error("Couldn't descramble, errored:", err)
+	}
+
+	if string(descrambledNonce) != nonce {
+		t.Error("Couldn't descramble nonce")
+	}
+
+	if string(descrambledText) != text {
+		t.Error("Couldn't descramble text")
+	}
+}
+
 func TestNonceDescramblingWithOverflow(t *testing.T) {
 	t.Parallel()
 

--- a/utils/oauth.go
+++ b/utils/oauth.go
@@ -101,7 +101,7 @@ func OauthMakeURL(service string) string {
 	// From which site the callback was from.
 	redirectURL := config.OAuthURL()
 	if service == github {
-		redirectURL += PrepareText(nonsenseState, AEAD_OAUTH) + "/"
+		redirectURL += PrepareText(nonsenseState, AEAD_OAUTH, config.ScrambleConfig) + "/"
 	} else {
 		redirectURL += service + "/"
 	}


### PR DESCRIPTION
Currently I had intentionally left the nonce very easy to get inside the encrypted text.

And thus would look like

`EncryptedMessageSendToUser = (nonce + base64(chachapoly2020(originialText)))`

And knowing the nonce and the given original text. It would be vulnerable to cryptoanalysis. Given the small size USw is, It would be a non-issue as it will still burn some GPU's to actually get the correct Secret_Key.

However as we are growing in size and now have been integrated into Stylus(beta). I should take a better look at the cryptographic functions and hashes we're using and how they could be vulnerable, I don't like to leave a little window open in a secure house.

Thus this is the best improvement so far in terms of crypto. We will now with this PR "scramble" the nonce at given places inside the text. This is actually something that big companies does in terms of adding nonce(however a bit different then we do. We re-use the recovered nonce, they don't). We can successfully recover this nonce and re-use it for decrypting the text given certain factors that we control, but they aren't know to (malicious) users and making it harder to actually know which encrypted test is being used and which is the nonce. 

@vednoc Please give it a good look. I've tried to add many comments as possible.