### PR TITLE
policy(CoC): Add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,117 @@
+# Kind Communications Guidelines
+
+We'd like to clarify that these rules is 
+not in relation to the site https://userstyles.world.
+But rather in relation of the open-source community spaces 
+around the code repository.
+
+This Code of Conduct/Guidelines is a modification 
+of the [GNU Kind Communcations Guideline](https://www.gnu.org/philosophy/kind-communication.html).
+
+## Purpose
+
+UserStyles.world("USw") encourages contributions from anyone who wishes to
+advance  the development of the USw platform, regardless of gender, race,
+ethnic group, physical appearance, religion, cultural background,
+and any other demographic characteristics, as well as personal political views.
+
+People could feel being discouraged from participating in USw development,
+because of certain patterns of communication that strike them as unfriendly,
+unwelcoming, rejecting, or harsh. This discouragement particularly
+affects members of disprivileged demographics, but it is not limited to them.
+Therefore, we ask all contributors to make a conscious effort, 
+in USw-related discussions, to communicate in ways that avoid the outcome.
+To avoid practices that will predictably and unnecessarily risk putting 
+some contributors off.
+
+These guidelines suggest specific ways to accomplish that goal.
+
+
+## Guidelines
+
+- Please assume other participants are posting in good faith, even if you
+  disagree with what they say. When people present code or text as their own
+  work, please accept it as their work. Please do not criticize people for
+  wrongs that you only speculate they may have done.
+
+- Please think about how to treat other participants with respect, especially
+  when you disagree with them. For instance, call them by the names they use,
+  and honor their preferences about their gender identity[1][#footnote].
+
+- Please do not take a harsh tone towards other participants, and especially
+  don't make personal attacks against them. Go out of your way 
+  to show that you are criticizing a statement, not a person.
+
+- Please recognize that criticism of your statements is not a personal 
+  attack on you. If you feel that someone has attacked you, or offended 
+  your personal dignity, please don't “hit back” with another personal attack.
+  That tends to start a vicious circle of escalating verbal aggression. 
+  A private response, politely stating your feelings as feelings, and asking
+  for peace, may calm things down. Write it, set it aside for hours or a day,
+  revise it to remove the anger, and only then send it.
+
+- Please avoid statements about the presumed typical desires, capabilities
+  or actions of some demographic group. They can offend people in that group,
+  and they are always off-topic in USw-related discussions.
+
+- Please be especially kind to other contributors when saying they made 
+  a mistake. Programming means making lots of mistakes, and we all do so—this
+  is why regression tests are useful. Conscientious programmers make mistakes,
+  and then fix them. It is helpful to show contributors that being imperfect
+  is normal, so we don't hold it against them, and that we appreciate their
+  imperfect contributions though we hope they follow through by fixing any
+  problems in them.
+
+- Please respond to what people actually said, not to exaggerations
+  of their views. Your criticism will not be constructive if it is aimed at
+  a target other than their real views.
+
+- If in a discussion someone brings up a tangent to the topic at hand,
+  please keep the discussion on track by focusing on the current topic
+  rather than the tangent. This is not to say that the tangent is bad, or not
+  interesting to discuss—only that it shouldn't interfere with discussion of
+  the issue at hand. In most cases, it is also off-topic, so those interested
+  ought to discuss it somewhere else.
+
+- If you think the tangent is an important and pertinent issue,
+  please bring it up as a separate discussion, with a Subject field to fit,
+   and consider waiting for the end of the current discussion.
+
+- Rather than trying to have the last word, look for the times when there is
+  no need to reply, perhaps because you already made the relevant point
+  clear enough. If you know something about the game of Go, this analogy might
+  clarify that: when the other player's move is not strong enough to require a
+  direct response, it is advantageous to give it none and instead move elsewhere.
+
+- Please don't argue unceasingly for your preferred course of action when a
+  decision for some other course has already been made. That tends to block
+  the activity's progress.
+    
+- If others have irritated you, perhaps by disregarding these guidelines,
+  please don't excoriate them, and especially please don't hold a grudge
+  against them. The constructive approach is to encourage and help other
+  people to do better. When they are trying to learn to do better, please
+  give them plenty of chances.
+
+- If other participants complain about the way you express your ideas, please
+  make an effort to cater to them. You can find ways to express the same points
+  while making others more comfortable. You are more likely to persuade others
+  if you don't arouse ire about secondary things.
+
+- Please don't raise unrelated political issues in USw-related discussions,
+  because they are off-topic.
+
+
+## Footnote
+
+By making an effort to follow these guidelines, we will encourage more
+contribution to our projects, and our discussions will be friendlier and
+reach conclusions more easily.
+
+Honoring people's preferences about gender identity includes not referring to
+them in ways that conflict with that identity, and using specific pronouns
+for it when those exist. If you know someone wishes to be considered male,
+it is best to use the masculine pronouns for him. If you know someone wishes to
+be considered female, it is best to use the feminine pronouns for her. Otherwise,
+use gender-neutral pronouns, since at least they don't conflict with anyone's
+gender identity. One choice is singular use of “they,” “them” and “their.”.


### PR DESCRIPTION
@vednoc This is a slightly modified template of the [contributer conviant v2](https://www.contributor-covenant.org/version/2/0/code_of_conduct/) to clarify that this code of conduct's scope is not intended for that USw site.