### PR TITLE
refactor(db): don't create new struct, instead pass-by-value

### DIFF
--- a/models/history.go
+++ b/models/history.go
@@ -18,10 +18,12 @@ type History struct {
 	TotalUpdates  int64
 }
 
+var modelHistory = History{}
+
 func (h History) GetStatsForStyle(id string) (q *[]History, err error) {
 	err = database.Conn.
 		Debug().
-		Model(History{}).
+		Model(modelHistory).
 		Where("style_id = ?", id).
 		Find(&q).
 		Error
@@ -35,7 +37,7 @@ func (h History) GetStatsForStyle(id string) (q *[]History, err error) {
 func (h History) GetStatsForAllStyles() (q *[]History, err error) {
 	err = database.Conn.
 		Debug().
-		Model(History{}).
+		Model(modelHistory).
 		Find(&q).
 		Error
 	if err != nil {

--- a/models/log.go
+++ b/models/log.go
@@ -44,11 +44,13 @@ type APILog struct {
 	TargetUserName string
 }
 
+var modelLog = Log{}
+
 // AddLog adds a new log to the database.
 func (l *Log) AddLog(logEntry *Log) (err error) {
 	err = database.Conn.
 		Debug().
-		Model(Log{}).
+		Model(modelLog).
 		Create(logEntry).
 		Error
 	if err != nil {
@@ -62,7 +64,7 @@ func (l *Log) AddLog(logEntry *Log) (err error) {
 func GetLogOfKind(kind LogKind) (q *[]APILog, err error) {
 	err = database.Conn.
 		Debug().
-		Model(Log{}).
+		Model(modelLog).
 		Select("logs.*, u.username").
 		Joins("join users u on u.id = logs.user_id").
 		Where("kind = ?", kind).

--- a/models/oauth.go
+++ b/models/oauth.go
@@ -39,6 +39,8 @@ type APIOAuth struct {
 // As gorm highly dislike slices, we have to implement, this ourself.
 type StringList []string
 
+var modelOAuth = OAuth{}
+
 func (s StringList) Value() (driver.Value, error) {
 	if len(s) == 0 {
 		return "[]", nil
@@ -69,9 +71,9 @@ func (OAuth) TableName() string {
 }
 
 func ListOAuthsOfUser(username string) (*[]APIOAuth, error) {
-	t, q := new(OAuth), new([]APIOAuth)
+	q := new([]APIOAuth)
 	err := getDBSession().
-		Model(t).
+		Model(modelOAuth).
 		Select("oauths.id, oauths.name, u.username").
 		Joins("join users u on u.id = oauths.user_id").
 		Find(q, "u.username = ?", username).
@@ -85,10 +87,10 @@ func ListOAuthsOfUser(username string) (*[]APIOAuth, error) {
 
 // GetOAuthByID note: Using ID as a string is fine in this case.
 func GetOAuthByID(id string) (*APIOAuth, error) {
-	t, q := new(OAuth), new(APIOAuth)
+	q := new(APIOAuth)
 	err := getDBSession().
 		Debug().
-		Model(t).
+		Model(modelOAuth).
 		Select("oauths.*,  u.username").
 		Joins("join users u on u.id = oauths.user_id").
 		First(q, "oauths.id = ?", id).
@@ -103,10 +105,10 @@ func GetOAuthByID(id string) (*APIOAuth, error) {
 
 // GetOAuthByClientID note: Using ID as a string is fine in this case.
 func GetOAuthByClientID(clientID string) (*APIOAuth, error) {
-	t, q := new(OAuth), new(APIOAuth)
+	q := new(APIOAuth)
 	err := getDBSession().
 		Debug().
-		Model(t).
+		Model(modelOAuth).
 		Select("oauths.*,  u.username").
 		Joins("join users u on u.id = oauths.user_id").
 		First(q, "oauths.client_id = ?", clientID).
@@ -134,7 +136,7 @@ func CreateOAuth(o *OAuth) (*OAuth, error) {
 func UpdateOAuth(o *OAuth, id string) error {
 	err := getDBSession().
 		Debug().
-		Model(OAuth{}).
+		Model(modelOAuth).
 		Where("id = ?", id).
 		Updates(o).
 		Error

--- a/models/review.go
+++ b/models/review.go
@@ -18,12 +18,14 @@ type Review struct {
 	StyleID int
 }
 
+var modelReview = Review{}
+
 func (r Review) FindAllForStyle(id interface{}) (q []Review, err error) {
 	err = database.Conn.
 		Debug().
 		// Preload(clause.Associations).
 		Preload("User").
-		Model(Review{}).
+		Model(modelReview).
 		Order("id DESC").
 		Find(&q, "style_id = ? ", id).
 		Error
@@ -48,7 +50,7 @@ func (r *Review) FindLastFromUser(styleID, userID interface{}) error {
 	return database.Conn.
 		Debug().
 		Preload("User").
-		Model(Review{}).
+		Model(modelReview).
 		Order("id DESC").
 		Last(&r, "style_id = ? and user_id = ?", styleID, userID).
 		Error

--- a/models/stats.go
+++ b/models/stats.go
@@ -36,6 +36,8 @@ type DashStats struct {
 	CountSum  int
 }
 
+var modelStats = Stats{}
+
 func (_ DashStats) GetCounts(t string) (q []DashStats, err error) {
 	stmt := "created_at, date(created_at) Date, count(distinct id) Count,"
 	stmt += "sum(count (distinct id)) over (order by date(created_at)) CountSum"
@@ -79,7 +81,7 @@ func AddStatsToStyle(id, ip string, install bool) (Stats, error) {
 
 	err = database.Conn.
 		Debug().
-		Model(s).
+		Model(modelStats).
 		Clauses(clause.OnConflict{
 			Columns:   []clause.Column{{Name: "hash"}},
 			DoUpdates: clause.Assignments(assignment),
@@ -97,7 +99,7 @@ func GetWeeklyInstallsForStyle(id string) (weekly int64) {
 	lastWeek := time.Now().Add(-time.Hour * 24 * 7)
 	q := "style_id = ? and install > 0 and created_at > ?"
 	database.Conn.
-		Model(Stats{}).
+		Model(modelStats).
 		Where(q, id, lastWeek).
 		Count(&weekly)
 
@@ -106,7 +108,7 @@ func GetWeeklyInstallsForStyle(id string) (weekly int64) {
 
 func GetTotalInstallsForStyle(id string) (total int64) {
 	database.Conn.
-		Model(Stats{}).
+		Model(modelStats).
 		Where("style_id = ? and install > 0", id).
 		Count(&total)
 
@@ -115,7 +117,7 @@ func GetTotalInstallsForStyle(id string) (total int64) {
 
 func GetTotalViewsForStyle(id string) (total int64) {
 	database.Conn.
-		Model(Stats{}).
+		Model(modelStats).
 		Where("style_id = ? and view > 0", id).
 		Count(&total)
 
@@ -126,7 +128,7 @@ func GetWeeklyUpdatesForStyle(id string) (weekly int64) {
 	lastWeek := time.Now().Add(-time.Hour * 24 * 7)
 	q := "style_id = ? and install > 0 and updated_at > ? and created_at < ?"
 	database.Conn.
-		Model(Stats{}).
+		Model(modelStats).
 		Where(q, id, lastWeek, lastWeek).
 		Count(&weekly)
 

--- a/models/style.go
+++ b/models/style.go
@@ -84,6 +84,8 @@ type StyleSearch struct {
 	UserID      uint
 }
 
+var modelStyle = Style{}
+
 func (s StyleCard) Slug() string {
 	return strings.SlugifyURL(s.Name)
 }
@@ -171,9 +173,9 @@ where
 }
 
 func GetAllStyleIDs() ([]APIStyle, error) {
-	t, q := new(Style), new([]APIStyle)
+	q := new([]APIStyle)
 	err := getDBSession().
-		Model(t).
+		Model(modelStyle).
 		Select("styles.id").
 		Find(q).
 		Error
@@ -185,7 +187,7 @@ func GetAllStyleIDs() ([]APIStyle, error) {
 }
 
 func GetAllStylesForIndexAPI() (*[]APIStyle, error) {
-	t, q := new(Style), new([]APIStyle)
+	q := new([]APIStyle)
 
 	s := "styles.id, styles.name, styles.created_at, styles.updated_at, "
 	s += "styles.description, styles.notes, styles.license, styles.homepage, "
@@ -193,7 +195,7 @@ func GetAllStylesForIndexAPI() (*[]APIStyle, error) {
 	s += "styles.homepage, styles.mirror_url, u.username, u.display_name"
 
 	err := getDBSession().
-		Model(t).
+		Model(modelStyle).
 		Select(s).
 		Joins("join users u on u.id = styles.user_id").
 		Find(q).
@@ -206,7 +208,7 @@ func GetAllStylesForIndexAPI() (*[]APIStyle, error) {
 }
 
 func GetStyleCount() (i int64, err error) {
-	if err := database.Conn.Select("count(id)").Model(Style{}).Count(&i).Error; err != nil {
+	if err := database.Conn.Select("count(id)").Model(modelStyle).Count(&i).Error; err != nil {
 		return 0, err
 	}
 
@@ -303,9 +305,9 @@ where
 }
 
 func GetImportedStyles() ([]Style, error) {
-	t, q := new(Style), new([]Style)
+	q := new([]Style)
 	err := getDBSession().
-		Model(t).
+		Model(modelStyle).
 		Find(q, "styles.mirror_url <> '' or styles.original <> '' and styles.mirror_code = ?", true).
 		Error
 	if err != nil {
@@ -317,9 +319,9 @@ func GetImportedStyles() ([]Style, error) {
 
 // GetStyleByID note: Using ID as a string is fine in this case.
 func GetStyleByID(id string) (*APIStyle, error) {
-	t, q := new(Style), new(APIStyle)
+	q := new(APIStyle)
 	err := getDBSession().
-		Model(t).
+		Model(modelStyle).
 		Select("styles.*,  u.username").
 		Joins("join users u on u.id = styles.user_id").
 		Find(q, "styles.id = ?", id).
@@ -367,7 +369,7 @@ func CreateStyle(s *Style) (*Style, error) {
 
 func UpdateStyle(s *Style) error {
 	err := getDBSession().
-		Model(Style{}).
+		Model(modelStyle).
 		Where("id", s.ID).
 		Updates(s).
 		Error
@@ -379,9 +381,9 @@ func UpdateStyle(s *Style) error {
 }
 
 func GetStyleSourceCodeAPI(id string) (*APIStyle, error) {
-	t, q := new(Style), new(APIStyle)
+	q := new(APIStyle)
 	err := getDBSession().
-		Model(t).
+		Model(modelStyle).
 		Select("styles.*, u.username").
 		Joins("join users u on u.id = styles.user_id").
 		First(q, "styles.id = ?", id).

--- a/models/user.go
+++ b/models/user.go
@@ -48,6 +48,8 @@ type APIUser struct {
 	Scopes      StringList
 }
 
+var modelUser = User{}
+
 // HasSocials checks if user set any social media.
 func (u User) HasSocials() bool {
 	return u.Socials.Codeberg != "" ||
@@ -149,7 +151,7 @@ func FindUserByID(id string) (*User, error) {
 	user := new(User)
 
 	err := getDBSession().
-		Model(User{}).
+		Model(modelUser).
 		Where("id = ?", id).
 		First(&user).
 		Error
@@ -167,7 +169,7 @@ func FindUserByID(id string) (*User, error) {
 func UpdateUser(u *User) error {
 	err := getDBSession().
 		Debug().
-		Model(User{}).
+		Model(modelUser).
 		Where("id", u.ID).
 		Updates(u).
 		Error


### PR DESCRIPTION
This is a little improvement to ensure that the db operations aren't getting a big overhead. Eventually we should have a system to use `sync.Pool` with other structs/objects that are used a lot, to ensure low-overhead from the GC.