### PR TITLE
Allow to log in as regular user in localhost

### DIFF
--- a/modules/database/init/init.go
+++ b/modules/database/init/init.go
@@ -176,12 +176,12 @@ func seed() {
 			Username:  "moderator",
 			Email:     "moderator@usw.local",
 			Biography: "I'm a moderator.",
-			Password:  utils.GenerateHashedPassword("moderator"),
+			Password:  utils.GenerateHashedPassword("moderator123"),
 		},
 		{
 			Username: "regular",
 			Email:    "regular@usw.local",
-			Password: utils.GenerateHashedPassword("regular"),
+			Password: utils.GenerateHashedPassword("regular123"),
 		},
 	}
 


### PR DESCRIPTION
This allows to log in as regular user (password is 8 chars minimum) as well as improves the passwords consistency.