### PR TITLE
Sorting unification

### DIFF
--- a/web/scss/components/form.scss
+++ b/web/scss/components/form.scss
@@ -9,7 +9,7 @@
     &-inline {
         display: flex;
 
-        .Form-section { margin-right: 1rem }
+        .Form-section:not(:last-child) { margin-right: 1rem }
 
         @media screen and (max-width: 878.8px) {
             flex-direction: column;

--- a/web/views/core/explore.html
+++ b/web/views/core/explore.html
@@ -7,17 +7,7 @@
     <section class="mt:l">
         <form class="Form Form-inline jc:c" method="get" action="/explore">
             <input type="text" name="page" value="1" hidden>
-            <div class="Form-section Form-row">
-                {{ template "partials/form-sort" . }}
-            </div>
-            <div class="Form-control">
-                <noscript>
-                    <button
-                        type="submit"
-                        class="btn icon primary"
-                    >{{ template "icons/search" }} Sort</button>
-                </noscript>
-            </div>
+            {{ template "partials/form-sort" . }}
         </form>
 
         {{ if gt (len .Styles) 1 }}

--- a/web/views/core/search.html
+++ b/web/views/core/search.html
@@ -25,9 +25,7 @@
                 >{{ template "icons/search" }} Search</button>
             </div>
 
-            <div class="Form-section Form-row ml:a">
-                {{ template "partials/form-sort" . }}
-            </div>
+            {{ template "partials/form-sort" . }}
         </form>
     </section>
 

--- a/web/views/partials/form-sort.html
+++ b/web/views/partials/form-sort.html
@@ -1,15 +1,26 @@
-<label for="sort">Sort by</label>
-<div class="Form-menu">
-    <select onchange="this.form.submit()" class="Form-select" id="sort" name="sort">
-        <option {{ if eq .Sort "" }}selected{{ end }} value="default">Default</option>
-        <option {{ if eq .Sort "newest" }}selected{{ end }} value="newest">Newest</option>
-        <option {{ if eq .Sort "oldest" }}selected{{ end }} value="oldest">Oldest</option>
-        <option {{ if eq .Sort "recentlyupdated" }}selected{{ end }} value="recentlyupdated">Recently updated</option>
-        <option {{ if eq .Sort "leastupdated" }}selected{{ end }} value="leastupdated">Least recently updated</option>
-        <option {{ if eq .Sort "mostinstalls" }}selected{{ end }} value="mostinstalls">Most installs</option>
-        <option {{ if eq .Sort "leastinstalls" }}selected{{ end }} value="leastinstalls">Least installs</option>
-        <option {{ if eq .Sort "mostviews" }}selected{{ end }} value="mostviews">Most views</option>
-        <option {{ if eq .Sort "leastviews" }}selected{{ end }} value="leastviews">Least views</option>
-    </select>
-    {{ template "icons/chevron-down" }}
+<div class="Form-section Form-row ml:a">
+    <label for="sort">Sort by</label>
+    <div class="Form-menu">
+        <select onchange="this.form.submit()" class="Form-select" id="sort" name="sort">
+            <option {{ if eq .Sort "" }}selected{{ end }} value="default">Default</option>
+            <option {{ if eq .Sort "newest" }}selected{{ end }} value="newest">Newest</option>
+            <option {{ if eq .Sort "oldest" }}selected{{ end }} value="oldest">Oldest</option>
+            <option {{ if eq .Sort "recentlyupdated" }}selected{{ end }} value="recentlyupdated">Recently updated</option>
+            <option {{ if eq .Sort "leastupdated" }}selected{{ end }} value="leastupdated">Least recently updated</option>
+            <option {{ if eq .Sort "mostinstalls" }}selected{{ end }} value="mostinstalls">Most installs</option>
+            <option {{ if eq .Sort "leastinstalls" }}selected{{ end }} value="leastinstalls">Least installs</option>
+            <option {{ if eq .Sort "mostviews" }}selected{{ end }} value="mostviews">Most views</option>
+            <option {{ if eq .Sort "leastviews" }}selected{{ end }} value="leastviews">Least views</option>
+        </select>
+        {{ template "icons/chevron-down" }}
+    </div>
+
+    <div class="Form-control">
+        <noscript>
+            <button
+                type="submit"
+                class="btn icon primary ml:m"
+            >{{ template "icons/search" }} Sort</button>
+        </noscript>
+    </div>
 </div>

--- a/web/views/user/profile.html
+++ b/web/views/user/profile.html
@@ -88,21 +88,11 @@
                     class="Form Form-inline jc:c ml:a"
                     method="get" action="/user/{{ .Profile.Username }}">
                     <input type="text" name="page" value="1" hidden>
-                    <div class="Form-section Form-row">
-                        {{ template "partials/form-sort" . }}
-                    </div>
-                    <div class="Form-control">
-                        <noscript>
-                            <button
-                                type="submit"
-                                class="btn icon primary"
-                            >{{ template "icons/search" }} Sort</button>
-                        </noscript>
-                    </div>
+                    {{ template "partials/form-sort" . }}
                 </form>
             </div>
             {{/* template "partials/debug-styles" . */}}
-            <div class="grid  flex rwrap mx:r mt:m">
+            <div class="grid flex rwrap mx:r mt:m">
                 {{ range .Styles }}
                     {{ template "partials/style-card" . }}
                 {{ end }}


### PR DESCRIPTION
This PR makes the noscript Sort button part of the Sort partial so it's not duplicated in Profiles and Explore and also shown in Search since the position of the Search button isn't the best here in case of noscript.
It also moves it to right in Explore so it's always in one spot.