### PR TITLE
Fix separator visibility in the Options dropdown

### DIFF
--- a/web/views/style/view.tmpl
+++ b/web/views/style/view.tmpl
@@ -84,8 +84,8 @@
 								data-tooltip="Mirror your userstyle. You can do this once per hour."
 							>{{ template "icons/refresh" }} Mirror</a>
 						</li>
+                        <li class="Dropdown-divider" role="separator"></li>
 					{{ end }}
-					<li class="Dropdown-divider" role="separator"></li>
 					<li><a href="/delete/{{ .Style.ID }}" class="danger">{{ template "icons/trash" }} Delete</a></li>
 				</ul>
 			</div>


### PR DESCRIPTION
This PR fixes visibility of the separator in the Options dropdown on Style page after [this commit](https://github.com/userstyles-world/userstyles.world/commit/e448ab5288e5e75a83128c7546340b9a47f4eab2#diff-2fec306129c0ed5832a7174d70f9ea080329c1198eeda26cc6894afb5a94d20aR66).
I guess this will require some more attention in case of adding something to these options.
VScode stole spaces on line 104 and i was not able to return them with Kate or Kwrite so apparently we have to go with that.