### PR TITLE
Improve consistency

### DIFF
--- a/handlers/style/add.go
+++ b/handlers/style/add.go
@@ -110,7 +110,7 @@ func CreatePost(c *fiber.Ctx) error {
 	if err != nil {
 		log.Warn.Println("Failed to create style:", err.Error())
 		return c.Render("err", fiber.Map{
-			"Title": "Internal server error.",
+			"Title": "Internal server error",
 			"User":  u,
 		})
 	}

--- a/handlers/style/ban.go
+++ b/handlers/style/ban.go
@@ -22,7 +22,7 @@ func BanGet(c *fiber.Ctx) error {
 	if !u.IsModOrAdmin() {
 		c.Status(fiber.StatusUnauthorized)
 		return c.Render("err", fiber.Map{
-			"Title": "Can't do that",
+			"Title": "You don't have enough permission for this",
 			"User":  u,
 		})
 	}
@@ -88,7 +88,7 @@ func BanPost(c *fiber.Ctx) error {
 	if !u.IsModOrAdmin() {
 		c.Status(fiber.StatusUnauthorized)
 		return c.Render("err", fiber.Map{
-			"Title": "Can't do that",
+			"Title": "You don't have enough permission for this",
 			"User":  u,
 		})
 	}
@@ -119,7 +119,7 @@ func BanPost(c *fiber.Ctx) error {
 	if err := modlog.AddLog(&logEntry); err != nil {
 		log.Warn.Printf("Failed to add style %d to ModLog: %s", s.ID, err.Error())
 		return c.Render("err", fiber.Map{
-			"Title": "Internal server error.",
+			"Title": "Internal server error",
 			"User":  u,
 		})
 	}

--- a/handlers/style/ban.go
+++ b/handlers/style/ban.go
@@ -22,7 +22,7 @@ func BanGet(c *fiber.Ctx) error {
 	if !u.IsModOrAdmin() {
 		c.Status(fiber.StatusUnauthorized)
 		return c.Render("err", fiber.Map{
-			"Title": "You don't have enough permission for this",
+			"Title": "You are not authorized to perform this action",
 			"User":  u,
 		})
 	}

--- a/handlers/style/ban.go
+++ b/handlers/style/ban.go
@@ -88,7 +88,7 @@ func BanPost(c *fiber.Ctx) error {
 	if !u.IsModOrAdmin() {
 		c.Status(fiber.StatusUnauthorized)
 		return c.Render("err", fiber.Map{
-			"Title": "You don't have enough permission for this",
+			"Title": "You are not authorized to perform this action",
 			"User":  u,
 		})
 	}

--- a/handlers/style/edit.go
+++ b/handlers/style/edit.go
@@ -70,20 +70,20 @@ func EditPost(c *fiber.Ctx) error {
 	// TODO: Implement proper validation.
 	s.Name = strings.TrimSpace(c.FormValue("name"))
 	if s.Name == "" {
-		args["Error"] = "Name field can't be empty"
+		args["Error"] = "Name field can't be empty."
 		return c.Render("style/create", args)
 	}
 
 	// Check userstyle name length
 	if len(s.Name) > 50 {
-		args["Error"] = "Name is too long"
+		args["Error"] = "Name must be up to 50 characters."
 		return c.Render("style/create", args)
 	}
 
 	// Check userstyle description length
 	s.Description = strings.TrimSpace(c.FormValue("description"))
 	if len(s.Description) > 160 {
-		args["Error"] = "Description is too long"
+		args["Error"] = "Description must be up to 160 characters."
 		return c.Render("style/create", args)
 	}
 
@@ -91,7 +91,7 @@ func EditPost(c *fiber.Ctx) error {
 	// TODO: figure some smaller limit, also update it in create.tmpl
 	s.Notes = strings.TrimSpace(c.FormValue("notes"))
 	if len(s.Notes) > 50000 {
-		args["Error"] = "Notes are too long"
+		args["Error"] = "Notes must be up to 50000 characters."
 		return c.Render("style/create", args)
 	}
 
@@ -101,7 +101,7 @@ func EditPost(c *fiber.Ctx) error {
 	// TODO: figure some limit, also update it in create.tmpl
 	s.Code = util.RemoveUpdateURL(c.FormValue("code"))
 	if len(s.Code) > 10000000 {
-		args["Error"] = "Code is too long"
+		args["Error"] = "Code must be up to 10000000 characters."
 		return c.Render("style/create", args)
 	}
 
@@ -145,7 +145,7 @@ func EditPost(c *fiber.Ctx) error {
 	if err = models.SelectUpdateStyle(s); err != nil {
 		log.Database.Printf("Failed to update style %d: %s\n", s.ID, err)
 		args["Title"] = "Failed to update userstyle"
-		args["Error"] = "Failed to update style in database"
+		args["Error"] = "Failed to update style in database."
 		return c.Render("style/create", args)
 	}
 

--- a/handlers/style/import.go
+++ b/handlers/style/import.go
@@ -34,7 +34,7 @@ func ImportPost(c *fiber.Ctx) error {
 	// Check if someone tries submitting local userstyle.
 	if strings.Contains(r, "file:///") {
 		return c.Render("err", fiber.Map{
-			"Title": "Can't import local userstyles.",
+			"Title": "Can't import local userstyles",
 			"User":  u,
 		})
 	}
@@ -104,7 +104,7 @@ func ImportPost(c *fiber.Ctx) error {
 	if err != nil {
 		log.Warn.Println("Failed to import style from URL:", err.Error())
 		return c.Render("err", fiber.Map{
-			"Title": "Internal server error.",
+			"Title": "Internal server error",
 			"User":  u,
 		})
 	}

--- a/handlers/style/promote.go
+++ b/handlers/style/promote.go
@@ -59,7 +59,7 @@ func Promote(c *fiber.Ctx) error {
 	// Only moderator and above have permissions to promote styles.
 	if u.Role < models.Moderator {
 		return c.Render("err", fiber.Map{
-			"Title": "You don't have enough permission for this.",
+			"Title": "You don't have enough permission for this",
 			"User":  u,
 		})
 	}
@@ -77,7 +77,7 @@ func Promote(c *fiber.Ctx) error {
 	if err != nil {
 		log.Warn.Println("Failed to get the style:", err.Error())
 		return c.Render("err", fiber.Map{
-			"Title": "Internal server error.",
+			"Title": "Internal server error",
 			"User":  u,
 		})
 	}

--- a/handlers/style/promote.go
+++ b/handlers/style/promote.go
@@ -59,7 +59,7 @@ func Promote(c *fiber.Ctx) error {
 	// Only moderator and above have permissions to promote styles.
 	if u.Role < models.Moderator {
 		return c.Render("err", fiber.Map{
-			"Title": "You don't have enough permission for this",
+			"Title": "You are not authorized to perform this action",
 			"User":  u,
 		})
 	}

--- a/handlers/style/review.go
+++ b/handlers/style/review.go
@@ -117,7 +117,7 @@ func ReviewPost(c *fiber.Ctx) error {
 			"Title":   "Review style",
 			"User":    u,
 			"ID":      id,
-			"Error":   "Rating is out of range",
+			"Error":   "Rating is out of range.",
 			"Rating":  r,
 			"Comment": cmt,
 		})
@@ -129,7 +129,7 @@ func ReviewPost(c *fiber.Ctx) error {
 			"Title":   "Review style",
 			"User":    u,
 			"ID":      id,
-			"Error":   "Comment can't be longer than 500 characters",
+			"Error":   "Comment can't be longer than 500 characters.",
 			"Rating":  r,
 			"Comment": cmt,
 		})

--- a/handlers/user/account.go
+++ b/handlers/user/account.go
@@ -138,7 +138,7 @@ func EditAccount(c *fiber.Ctx) error {
 				"Title":  "Validation Error",
 				"User":   u,
 				"Params": user,
-				"Error":  "Biography must be shorter than 1000 characters.",
+				"Error":  "Biography must be up to 1000 characters.",
 			})
 		}
 
@@ -191,7 +191,7 @@ func EditAccount(c *fiber.Ctx) error {
 	if dbErr != nil {
 		log.Warn.Println("Updating user profile failed, err:", err)
 		return c.Render("err", fiber.Map{
-			"Title": "Internal server error.",
+			"Title": "Internal server error",
 			"User":  u,
 		})
 	}

--- a/handlers/user/ban.go
+++ b/handlers/user/ban.go
@@ -115,7 +115,7 @@ func ConfirmBan(c *fiber.Ctx) error {
 	if err := user.DeleteWhereID(targetUser.ID); err != nil {
 		log.Warn.Printf("Failed to ban user %d: %s\n", id, err.Error())
 		return c.Render("err", fiber.Map{
-			"Title": "Internal server error.",
+			"Title": "Internal server error",
 			"User":  u,
 		})
 	}
@@ -125,7 +125,7 @@ func ConfirmBan(c *fiber.Ctx) error {
 	if err := styles.BanWhereUserID(targetUser.ID); err != nil {
 		log.Warn.Printf("Failed to ban styles from user %d: %s\n", id, err.Error())
 		return c.Render("err", fiber.Map{
-			"Title": "Internal server error.",
+			"Title": "Internal server error",
 			"User":  u,
 		})
 	}
@@ -145,7 +145,7 @@ func ConfirmBan(c *fiber.Ctx) error {
 	if err := modlog.AddLog(&logEntry); err != nil {
 		log.Warn.Printf("Failed to add user %d to ModLog: %s\n", targetUser.ID, err.Error())
 		return c.Render("err", fiber.Map{
-			"Title": "Internal server error.",
+			"Title": "Internal server error",
 			"User":  u,
 		})
 	}

--- a/handlers/user/login.go
+++ b/handlers/user/login.go
@@ -90,7 +90,7 @@ func LoginPost(c *fiber.Ctx) error {
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).
 			Render("err", fiber.Map{
-				"Title": "Internal server error.",
+				"Title": "Internal server error",
 			})
 	}
 
@@ -111,7 +111,7 @@ func LoginPost(c *fiber.Ctx) error {
 		if err != nil {
 			return c.Status(fiber.StatusInternalServerError).
 				Render("err", fiber.Map{
-					"Title": "Internal server error.",
+					"Title": "Internal server error",
 				})
 		}
 		return c.Redirect(path, fiber.StatusSeeOther)

--- a/handlers/user/reset.go
+++ b/handlers/user/reset.go
@@ -129,7 +129,7 @@ func ResetPost(c *fiber.Ctx) error {
 	if err != nil {
 		log.Warn.Println("Failed to update user:", err.Error())
 		return c.Render("err", fiber.Map{
-			"Title": "Internal server error.",
+			"Title": "Internal server error",
 			"Error": "Internal server error.",
 		})
 	}

--- a/web/scss/ui/_base.scss
+++ b/web/scss/ui/_base.scss
@@ -153,6 +153,9 @@ hr { border: none; border-top: 1px solid var(--bg-3)  }
     }
 }
 
+.alert .limit { max-width: 100% }
+.styles { max-width: var(--form-max-width) }
+
 input[type="checkbox"],
 label[for="remember"] {
     width: unset;

--- a/web/views/oauth/settings.tmpl
+++ b/web/views/oauth/settings.tmpl
@@ -15,10 +15,6 @@
 </section>
 
 <section class="alert">
-	<style type="text/css">
-		.alert > .limit { max-width: 100% }
-		.styles { max-width: var(--form-max-width) }
-	</style>
 	{{ template "partials/alert" . }}
 </section>
 

--- a/web/views/style/create.tmpl
+++ b/web/views/style/create.tmpl
@@ -30,7 +30,6 @@
 			margin: 0 auto;
 			padding: 0;
 		}
-		.alert > .limit { max-width: 100% }
 	</style>
 	{{ template "partials/alert" . }}
 </section>

--- a/web/views/user/account.tmpl
+++ b/web/views/user/account.tmpl
@@ -1,4 +1,6 @@
-{{ template "partials/alert" . }}
+<section class="alert">
+	{{ template "partials/alert" . }}
+</section>
 
 <section id="welcome">
 	<h1 class="title">Hi, {{ .Params.Name }}!</h1>


### PR DESCRIPTION
- no dots in titles;
- dots in errors;
- same permission error for ban and promote;
- same length error for style editing and biography as for input validity. Biography is actually up to 1000, not shorter than;
- move some alert CSS rules from HTMLs to _base;
- properly looking alert on settings page. I hope i did not break alerts in other places. I tested search, account edit, style edit, login form.