### PR TITLE
Fix project roadmap link

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -4,7 +4,7 @@ userstyles, and a replacement for =UserStyles.org=, made by the userstyles
 community.
 
 ** Features
-Features are implemented as they are needed. Visit our [[https://github.com/userstyles-world/userstyles.world/projects/1][public roadmap]] to see
+Features are implemented as they are needed. Visit our [[https://github.com/orgs/userstyles-world/projects/1][public roadmap]] to see
 what we're working on, and feel free to open an issue to request new features.
 
 *** Core User functionality:

--- a/web/views/partials/footer.tmpl
+++ b/web/views/partials/footer.tmpl
@@ -31,7 +31,7 @@
 			<li><b class="mb:s">Support and links</b></li>
 			<li>{{ template "icons/github" }}<a target="_blank" rel="noopener" href="{{ config "appSourceCode" }}">Source code</a></li>
 			<li>{{ template "icons/github" }}<a target="_blank" rel="noopener" href="{{ config "appSourceCode" }}/issues/new/choose">Open an issue</a></li>
-			<li>{{ template "icons/github" }}<a target="_blank" rel="noopener" href="{{ config "appSourceCode" }}/projects/1">Project roadmap</a></li>
+			<li>{{ template "icons/github" }}<a target="_blank" rel="noopener" href="https://github.com/orgs/userstyles-world/projects/1">Project roadmap</a></li>
 			<li>{{ template "icons/element" }} <a target="_blank" rel="noopener" href="/link/matrix">Chat on Matrix</a></li>
 			<li>{{ template "icons/discord" }} <a target="_blank" rel="noopener" href="/link/discord">Chat on Discord</a></li>
 			<li>{{ template "icons/opencollective" }} <a target="_blank" rel="noopener" href="/link/opencollective">Support the project</a></li>


### PR DESCRIPTION
Currently, these links point to a closed "Classic" project, which can be confusing to those who click on them.