### PR TITLE
Private style URLs

### DIFF
--- a/handlers/style/edit.go
+++ b/handlers/style/edit.go
@@ -63,6 +63,8 @@ func EditPost(c *fiber.Ctx) error {
 	s.Homepage = strings.TrimSpace(c.FormValue("homepage"))
 	s.License = strings.TrimSpace(c.FormValue("license", "No License"))
 	s.MirrorURL = strings.TrimSpace(c.FormValue("mirrorURL"))
+	s.ImportPrivate = c.FormValue("importPrivate") == "on"
+	s.MirrorPrivate = c.FormValue("mirrorPrivate") == "on"
 	s.MirrorCode = c.FormValue("mirrorCode") == "on"
 	s.MirrorMeta = c.FormValue("mirrorMeta") == "on"
 	c.Locals("Style", s)

--- a/handlers/style/import.go
+++ b/handlers/style/import.go
@@ -97,10 +97,9 @@ func ImportPost(c *fiber.Ctx) error {
 		}
 	}
 
+	// Enable code/meta mirroring.
 	s.ImportPrivate = c.FormValue("importPrivate") == "on"
 	s.MirrorPrivate = c.FormValue("mirrorPrivate") == "on"
-
-	// Enable code/meta mirroring.
 	s.MirrorCode = c.FormValue("mirrorCode") == "on"
 	s.MirrorMeta = c.FormValue("mirrorMeta") == "on"
 

--- a/handlers/style/import.go
+++ b/handlers/style/import.go
@@ -97,6 +97,9 @@ func ImportPost(c *fiber.Ctx) error {
 		}
 	}
 
+	s.ImportPrivate = c.FormValue("importPrivate") == "on"
+	s.MirrorPrivate = c.FormValue("mirrorPrivate") == "on"
+
 	// Enable code/meta mirroring.
 	s.MirrorCode = c.FormValue("mirrorCode") == "on"
 	s.MirrorMeta = c.FormValue("mirrorMeta") == "on"

--- a/models/style.go
+++ b/models/style.go
@@ -346,10 +346,20 @@ func SelectUpdateStyle(s Style) error {
 		Updates(s).Error
 }
 
+// MirrorEnabled returns whether or not mirroring is enabled.
+func (s *APIStyle) MirrorEnabled() bool {
+	return s.MirrorCode || s.MirrorMeta
+}
+
+// SameMirrorURL returns whether or not mirror URL matches import URL.
+func (s *APIStyle) SameMirrorURL() bool {
+	return s.MirrorURL == "" || s.Original == s.MirrorURL
+}
+
 // ImportedAndMirrored returns whether or not a userstyle is imported and
 // mirrored from the same URLs.
 func (s *APIStyle) ImportedAndMirrored() bool {
-	return s.Imported() && s.Mirrored() && (s.Original == s.MirrorURL || s.MirrorURL == "")
+	return s.Imported() && s.MirrorEnabled() && s.SameMirrorURL()
 }
 
 // ImportedAndMirroredText returns from which location a userstyle is imported
@@ -376,7 +386,7 @@ func (s *APIStyle) ImportedText() string {
 
 // Mirrored returns whether or not a userstyle is mirrored.
 func (s *APIStyle) Mirrored() bool {
-	return s.MirrorCode || s.MirrorMeta
+	return s.MirrorURL != "" && s.MirrorEnabled()
 }
 
 // MirroredText returns from which location a userstyle is mirrored.

--- a/models/style.go
+++ b/models/style.go
@@ -347,58 +347,42 @@ func SelectUpdateStyle(s Style) error {
 }
 
 // CompareMirrorURL will return true if a style is being imported and mirrored,
-// and both URLs are public or private from the same URL.
+// and both URLs are public.
 func (s *APIStyle) CompareMirrorURL() bool {
 	if s.Original != "" &&
 		(s.MirrorCode || s.MirrorMeta) &&
-		(s.MirrorURL == "" || s.MirrorURL == s.Original) {
+		(s.MirrorURL == "" || s.MirrorURL == s.Original) &&
+		!(s.ImportPrivate || s.MirrorPrivate) {
 		return true
 	}
 
 	return false
 }
 
-// IsMirrored will return true if a style is being mirrored.
-func (s *APIStyle) IsMirrored() bool {
-	if s.MirrorURL != "" &&
-		(s.MirrorCode || s.MirrorMeta) {
-		return true
-	}
-
-	return false
+func (s *APIStyle) ImportedAndMirroredText() string {
+	return "Imported and mirrored from <code>" + s.Original + "</code>"
 }
 
-// HeadlineText prints imported and/or mirrored URLs.
-func (s *APIStyle) HeadlineText() string {
-	var res string
-	switch {
-	case s.CompareMirrorURL() && !(s.ImportPrivate || s.MirrorPrivate):
-		res = fmt.Sprintf("<p class=\"mb:m md\">Imported and mirrored from <code>%s</code></p>", s.Original)
+func (s *APIStyle) ImportedCondition() bool {
+	return s.Original != ""
+}
 
-	case s.ImportPrivate || s.MirrorPrivate:
-		if s.Original != "" {
-			res = "<p class=\"mb:m md\">Imported"
-			if !s.ImportPrivate {
-				res += fmt.Sprintf(" from <code>%s</code>", s.Original)
-			}
-			res += "</p>"
-		}
-		if s.IsMirrored() {
-			res += "<p class=\"mb:m md\">Mirrored"
-			if !s.MirrorPrivate {
-				res += fmt.Sprintf(" from <code>%s</code>", s.MirrorURL)
-			}
-			res += "</p>"
-		}
+func (s *APIStyle) MirroredCondition() bool {
+	return s.MirrorURL != "" && (s.MirrorCode || s.MirrorMeta)
+}
 
-	default:
-		if s.Original != "" {
-			res = fmt.Sprintf("<p class=\"mb:m md\">Imported from <code>%s</code></p>", s.Original)
-		}
-		if s.IsMirrored() {
-			res += fmt.Sprintf("<p class=\"mb:m md\">Mirrored from <code>%s</code></p>", s.MirrorURL)
-		}
+func (s *APIStyle) ImportedText() string {
+	t := "Imported"
+	if !s.ImportPrivate {
+		t += " from <code>" + s.Original + "</code>"
 	}
+	return t
+}
 
-	return res
+func (s *APIStyle) MirroredText() string {
+	t := "Mirrored"
+	if !s.MirrorPrivate {
+		t += " from <code>" + s.MirrorURL + "</code>"
+	}
+	return t
 }

--- a/models/style.go
+++ b/models/style.go
@@ -337,7 +337,7 @@ func (s *APIStyle) SetPreview() {
 func SelectUpdateStyle(s Style) error {
 	fields := []string{"name", "description", "notes", "code", "homepage",
 		"license", "category", "preview", "preview_version", "mirror_url",
-		"mirror_code", "mirror_meta"}
+		"mirror_code", "mirror_meta", "import_private", "mirror_private"}
 
 	return db().
 		Model(modelStyle).

--- a/models/style.go
+++ b/models/style.go
@@ -16,49 +16,51 @@ import (
 
 type Style struct {
 	gorm.Model
-	Original    string
-	MirrorURL   string
-	Homepage    string
-	Category    string `validate:"required,min=1,max=255" gorm:"not null"`
-	Name        string `validate:"required,min=1,max=50"`
-	Description string `validate:"required,min=1,max=160"`
-	Notes       string `validate:"min=0,max=50000"`
-	Code        string `validate:"max=10000000"`
-	License     string
-	Preview     string
-	User        User `gorm:"foreignKey:ID"`
-	UserID      uint `gorm:"index"`
-	Archived    bool `gorm:"default:false"`
-	Featured    bool `gorm:"default:false"`
-	MirrorCode  bool `gorm:"default:false"`
-	MirrorMeta  bool `gorm:"default:false"`
-
-	PreviewVersion int `gorm:"default:0"`
+	Original       string
+	MirrorURL      string
+	Homepage       string
+	Category       string `validate:"required,min=1,max=255" gorm:"not null"`
+	Name           string `validate:"required,min=1,max=50"`
+	Description    string `validate:"required,min=1,max=160"`
+	Notes          string `validate:"min=0,max=50000"`
+	Code           string `validate:"max=10000000"`
+	License        string
+	Preview        string
+	User           User `gorm:"foreignKey:ID"`
+	UserID         uint `gorm:"index"`
+	Archived       bool `gorm:"default:false"`
+	Featured       bool `gorm:"default:false"`
+	ImportPrivate  bool `gorm:"default:false"`
+	MirrorPrivate  bool `gorm:"default:false"`
+	MirrorCode     bool `gorm:"default:false"`
+	MirrorMeta     bool `gorm:"default:false"`
+	PreviewVersion int  `gorm:"default:0"`
 }
 
 type APIStyle struct {
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
-	Category    string    `json:"category"`
-	Name        string    `json:"name"`
-	Description string    `json:"description"`
-	Notes       string    `json:"notes"`
-	Code        string    `json:"-"`
-	License     string    `json:"license"`
-	Preview     string    `json:"preview_url"`
-	Homepage    string    `json:"homepage"`
-	Username    string    `json:"username"`
-	Original    string    `json:"original"`
-	MirrorURL   string    `json:"mirror_url"`
-	DisplayName string    `json:"display_name"`
-	UserID      uint      `json:"user_id"`
-	ID          uint      `json:"id"`
-	Featured    bool      `json:"-"`
-	MirrorCode  bool      `json:"-"`
-	MirrorMeta  bool      `json:"-"`
-	Archived    bool      `json:"-"`
-
-	PreviewVersion int `json:"-"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+	Category       string    `json:"category"`
+	Name           string    `json:"name"`
+	Description    string    `json:"description"`
+	Notes          string    `json:"notes"`
+	Code           string    `json:"-"`
+	License        string    `json:"license"`
+	Preview        string    `json:"preview_url"`
+	Homepage       string    `json:"homepage"`
+	Username       string    `json:"username"`
+	Original       string    `json:"original"`
+	MirrorURL      string    `json:"mirror_url"`
+	DisplayName    string    `json:"display_name"`
+	UserID         uint      `json:"user_id"`
+	ID             uint      `json:"id"`
+	Featured       bool      `json:"-"`
+	ImportPrivate  bool      `json:"-"`
+	MirrorPrivate  bool      `json:"-"`
+	MirrorCode     bool      `json:"-"`
+	MirrorMeta     bool      `json:"-"`
+	Archived       bool      `json:"-"`
+	PreviewVersion int       `json:"-"`
 }
 
 type StyleSiteMap struct {
@@ -344,12 +346,13 @@ func SelectUpdateStyle(s Style) error {
 		Updates(s).Error
 }
 
-// CompareMirrorURL will return true if a style is being imported and mirrored
+// CompareMirrorURL will return true if a style is being imported and mirrored, and both URLs are public or private
 // from the same URL.
 func (s *APIStyle) CompareMirrorURL() bool {
 	if s.Original != "" &&
 		(s.MirrorCode || s.MirrorMeta) &&
-		(s.MirrorURL == "" || s.MirrorURL == s.Original) {
+		(s.MirrorURL == "" || s.MirrorURL == s.Original) { /*&&
+		!(s.ImportPrivate || s.MirrorPrivate)*/
 		return true
 	}
 

--- a/models/style.go
+++ b/models/style.go
@@ -372,17 +372,16 @@ func (s *APIStyle) MirroredCondition() bool {
 }
 
 func (s *APIStyle) ImportedText() string {
-	t := "Imported"
-	if !s.ImportPrivate {
-		t += " from <code>" + s.Original + "</code>"
-	}
-	return t
+	return "Imported from " + ternary(s.ImportPrivate, "private source", "<code>"+s.Original+"</code>")
 }
 
 func (s *APIStyle) MirroredText() string {
-	t := "Mirrored"
-	if !s.MirrorPrivate {
-		t += " from <code>" + s.MirrorURL + "</code>"
+	return "Mirrored from " + ternary(s.MirrorPrivate, "private source", "<code>"+s.MirrorURL+"</code>")
+}
+
+func ternary(what bool, truetext string, falsetext string) string {
+	if what {
+		return truetext
 	}
-	return t
+	return falsetext
 }

--- a/models/style.go
+++ b/models/style.go
@@ -346,15 +346,10 @@ func SelectUpdateStyle(s Style) error {
 		Updates(s).Error
 }
 
-// MirrorEnabled returns whether or not a userstyle is mirrored.
-func (s *APIStyle) MirrorEnabled() bool {
-	return s.MirrorCode || s.MirrorMeta
-}
-
 // ImportedAndMirrored returns whether or not a userstyle is imported and
 // mirrored from the same URLs.
 func (s *APIStyle) ImportedAndMirrored() bool {
-	return s.Imported() && s.MirrorEnabled()
+	return s.Imported() && s.Mirrored() && (s.Original == s.MirrorURL || s.MirrorURL == "")
 }
 
 // ImportedAndMirroredText returns from which location a userstyle is imported
@@ -368,7 +363,7 @@ func (s *APIStyle) ImportedAndMirroredText() string {
 
 // Imported returns whether or not a userstyle is imported.
 func (s *APIStyle) Imported() bool {
-	return s.Original != "" && (s.MirrorURL == "" || s.Original == s.MirrorURL)
+	return s.Original != ""
 }
 
 // ImportedText returns from which location a userstyle is imported.
@@ -381,7 +376,7 @@ func (s *APIStyle) ImportedText() string {
 
 // Mirrored returns whether or not a userstyle is mirrored.
 func (s *APIStyle) Mirrored() bool {
-	return s.MirrorURL != "" && s.MirrorEnabled()
+	return s.MirrorCode || s.MirrorMeta
 }
 
 // MirroredText returns from which location a userstyle is mirrored.

--- a/models/style.go
+++ b/models/style.go
@@ -346,51 +346,60 @@ func SelectUpdateStyle(s Style) error {
 		Updates(s).Error
 }
 
-// MirrorEnabled returns whether or not mirroring is enabled.
-func (s *APIStyle) MirrorEnabled() bool {
+// mirrorEnabled returns whether or not mirroring is enabled.
+func (s *APIStyle) mirrorEnabled() bool {
 	return s.MirrorCode || s.MirrorMeta
 }
 
-// SameMirrorURL returns whether or not mirror URL matches import URL.
-func (s *APIStyle) SameMirrorURL() bool {
+// sameMirrorURL returns whether or not mirror URL matches import URL.
+func (s *APIStyle) sameMirrorURL() bool {
 	return s.MirrorURL == "" || s.Original == s.MirrorURL
 }
 
-// ImportedAndMirrored returns whether or not a userstyle is imported and
+// isImportedAndMirrored returns whether or not a userstyle is imported and
 // mirrored from the same URLs.
-func (s *APIStyle) ImportedAndMirrored() bool {
-	return s.Imported() && s.MirrorEnabled() && s.SameMirrorURL()
+func (s *APIStyle) isImportedAndMirrored() bool {
+	return s.isImported() && s.mirrorEnabled() && s.sameMirrorURL()
 }
 
-// ImportedAndMirroredText returns from which location a userstyle is imported
-// and mirrored.
-func (s *APIStyle) ImportedAndMirroredText() string {
+// ImportedAndMirrored returns from which location a userstyle is imported and
+// mirrored.
+func (s *APIStyle) ImportedAndMirrored() string {
+	if !s.isImportedAndMirrored() {
+		return ""
+	}
 	if s.ImportPrivate || s.MirrorPrivate {
 		return "Imported and mirrored from a private source"
 	}
 	return "Imported and mirrored from <code>" + s.Original + "</code>"
 }
 
-// Imported returns whether or not a userstyle is imported.
-func (s *APIStyle) Imported() bool {
+// isImported returns whether or not a userstyle is isImported.
+func (s *APIStyle) isImported() bool {
 	return s.Original != ""
 }
 
-// ImportedText returns from which location a userstyle is imported.
-func (s *APIStyle) ImportedText() string {
+// Imported returns from which location a userstyle is imported.
+func (s *APIStyle) Imported() string {
+	if !s.isImported() {
+		return ""
+	}
 	if s.ImportPrivate {
 		return "Imported from a private source"
 	}
 	return "Imported from <code>" + s.Original + "</code>"
 }
 
-// Mirrored returns whether or not a userstyle is mirrored.
-func (s *APIStyle) Mirrored() bool {
-	return s.MirrorURL != "" && s.MirrorEnabled()
+// isMirrored returns whether or not a userstyle is isMirrored.
+func (s *APIStyle) isMirrored() bool {
+	return s.MirrorURL != "" && s.mirrorEnabled()
 }
 
-// MirroredText returns from which location a userstyle is mirrored.
-func (s *APIStyle) MirroredText() string {
+// Mirrored returns from which location a userstyle is mirrored.
+func (s *APIStyle) Mirrored() string {
+	if !s.isMirrored() {
+		return ""
+	}
 	if s.MirrorPrivate {
 		return "Mirrored from a private source"
 	}

--- a/models/style.go
+++ b/models/style.go
@@ -357,3 +357,13 @@ func (s *APIStyle) CompareMirrorURL() bool {
 
 	return false
 }
+
+// IsMirrored will return true if a style is being mirrored.
+func (s *APIStyle) IsMirrored() bool {
+	if s.MirrorURL != "" &&
+		(s.MirrorCode || s.MirrorMeta) {
+		return true
+	}
+
+	return false
+}

--- a/models/style.go
+++ b/models/style.go
@@ -367,3 +367,48 @@ func (s *APIStyle) IsMirrored() bool {
 
 	return false
 }
+
+// HeadlineText prints imported and/or mirrored URLs.
+func (s *APIStyle) HeadlineText() string {
+	var res string
+	switch {
+	case s.CompareMirrorURL() && !(s.ImportPrivate || s.MirrorPrivate):
+		res = fmt.Sprintf("Imported and mirrored code from <code>%s</code>.", s.Original)
+
+	case s.ImportPrivate || s.MirrorPrivate:
+		if s.Original != "" {
+			res = "Imported"
+			if !s.ImportPrivate {
+				res += fmt.Sprintf(" from <code>%s</code>", s.Original)
+			}
+			if s.IsMirrored() {
+				res += ", "
+			} else {
+				res += "."
+			}
+		}
+		if s.IsMirrored() {
+			res += "Mirrored"
+			if !s.MirrorPrivate {
+				res += fmt.Sprintf(" from <code>%s</code>", s.MirrorURL)
+			}
+			res += "."
+		}
+
+	default:
+		if s.Original != "" {
+			res = fmt.Sprintf("Imported from <code>%s</code>", s.Original)
+			if s.IsMirrored() {
+				res += ", "
+			} else {
+				res += "."
+			}
+		}
+		if s.IsMirrored() {
+			res += fmt.Sprintf("<nobr>Mirrored from <code>%s</code>.</nobr>", s.MirrorURL)
+		}
+	}
+
+	return res
+}
+

--- a/models/style.go
+++ b/models/style.go
@@ -346,18 +346,19 @@ func SelectUpdateStyle(s Style) error {
 		Updates(s).Error
 }
 
-// CompareMirrorURL will return true if a style is being imported and mirrored,
-// and both URLs are public.
-func (s *APIStyle) CompareMirrorURL() bool {
-	if s.Original != "" &&
-		(s.MirrorCode || s.MirrorMeta) &&
-		(s.MirrorURL == "" || s.MirrorURL == s.Original) {
-		return true
-	}
-
-	return false
+// MirrorEnabled returns whether or not a userstyle is mirrored.
+func (s *APIStyle) MirrorEnabled() bool {
+	return s.MirrorCode || s.MirrorMeta
 }
 
+// ImportedAndMirrored returns whether or not a userstyle is imported and
+// mirrored from the same URLs.
+func (s *APIStyle) ImportedAndMirrored() bool {
+	return s.Imported() && s.MirrorEnabled()
+}
+
+// ImportedAndMirroredText returns from which location a userstyle is imported
+// and mirrored.
 func (s *APIStyle) ImportedAndMirroredText() string {
 	if s.ImportPrivate || s.MirrorPrivate {
 		return "Imported and mirrored from a private source"
@@ -365,14 +366,12 @@ func (s *APIStyle) ImportedAndMirroredText() string {
 	return "Imported and mirrored from <code>" + s.Original + "</code>"
 }
 
-func (s *APIStyle) ImportedCondition() bool {
-	return s.Original != ""
+// Imported returns whether or not a userstyle is imported.
+func (s *APIStyle) Imported() bool {
+	return s.Original != "" && (s.MirrorURL == "" || s.Original == s.MirrorURL)
 }
 
-func (s *APIStyle) MirroredCondition() bool {
-	return s.MirrorURL != "" && (s.MirrorCode || s.MirrorMeta)
-}
-
+// ImportedText returns from which location a userstyle is imported.
 func (s *APIStyle) ImportedText() string {
 	if s.ImportPrivate {
 		return "Imported from a private source"
@@ -380,6 +379,12 @@ func (s *APIStyle) ImportedText() string {
 	return "Imported from <code>" + s.Original + "</code>"
 }
 
+// Mirrored returns whether or not a userstyle is mirrored.
+func (s *APIStyle) Mirrored() bool {
+	return s.MirrorURL != "" && s.MirrorEnabled()
+}
+
+// MirroredText returns from which location a userstyle is mirrored.
 func (s *APIStyle) MirroredText() string {
 	if s.MirrorPrivate {
 		return "Mirrored from a private source"

--- a/models/style.go
+++ b/models/style.go
@@ -30,11 +30,11 @@ type Style struct {
 	UserID         uint `gorm:"index"`
 	Archived       bool `gorm:"default:false"`
 	Featured       bool `gorm:"default:false"`
-	ImportPrivate  bool `gorm:"default:false"`
-	MirrorPrivate  bool `gorm:"default:false"`
 	MirrorCode     bool `gorm:"default:false"`
 	MirrorMeta     bool `gorm:"default:false"`
 	PreviewVersion int  `gorm:"default:0"`
+	ImportPrivate  bool `gorm:"default:false"`
+	MirrorPrivate  bool `gorm:"default:false"`
 }
 
 type APIStyle struct {
@@ -55,12 +55,12 @@ type APIStyle struct {
 	UserID         uint      `json:"user_id"`
 	ID             uint      `json:"id"`
 	Featured       bool      `json:"-"`
-	ImportPrivate  bool      `json:"-"`
-	MirrorPrivate  bool      `json:"-"`
 	MirrorCode     bool      `json:"-"`
 	MirrorMeta     bool      `json:"-"`
 	Archived       bool      `json:"-"`
 	PreviewVersion int       `json:"-"`
+	ImportPrivate  bool      `json:"-"`
+	MirrorPrivate  bool      `json:"-"`
 }
 
 type StyleSiteMap struct {

--- a/models/style.go
+++ b/models/style.go
@@ -373,42 +373,41 @@ func (s *APIStyle) HeadlineText() string {
 	var res string
 	switch {
 	case s.CompareMirrorURL() && !(s.ImportPrivate || s.MirrorPrivate):
-		res = fmt.Sprintf("Imported and mirrored code from <code>%s</code>.", s.Original)
+		res = fmt.Sprintf("<p class=\"mb:m md\">Imported and mirrored code from <code>%s</code>.</p>", s.Original)
 
 	case s.ImportPrivate || s.MirrorPrivate:
 		if s.Original != "" {
-			res = "Imported"
+			res = "<p class=\"mb:m md\">Imported"
 			if !s.ImportPrivate {
 				res += fmt.Sprintf(" from <code>%s</code>", s.Original)
 			}
 			if s.IsMirrored() {
-				res += ", "
+				res += ",</p> "
 			} else {
-				res += "."
+				res += ".</p>"
 			}
 		}
 		if s.IsMirrored() {
-			res += "Mirrored"
+			res += "<p class=\"mb:m md\">Mirrored"
 			if !s.MirrorPrivate {
 				res += fmt.Sprintf(" from <code>%s</code>", s.MirrorURL)
 			}
-			res += "."
+			res += ".</p>"
 		}
 
 	default:
 		if s.Original != "" {
-			res = fmt.Sprintf("Imported from <code>%s</code>", s.Original)
+			res = fmt.Sprintf("<p class=\"mb:m md\">Imported from <code>%s</code>", s.Original)
 			if s.IsMirrored() {
-				res += ", "
+				res += ",</p> "
 			} else {
-				res += "."
+				res += ".</p>"
 			}
 		}
 		if s.IsMirrored() {
-			res += fmt.Sprintf("<nobr>Mirrored from <code>%s</code>.</nobr>", s.MirrorURL)
+			res += fmt.Sprintf("<p class=\"mb:m md\">Mirrored from <code>%s</code>.</p>", s.MirrorURL)
 		}
 	}
 
 	return res
 }
-

--- a/models/style.go
+++ b/models/style.go
@@ -346,13 +346,12 @@ func SelectUpdateStyle(s Style) error {
 		Updates(s).Error
 }
 
-// CompareMirrorURL will return true if a style is being imported and mirrored, and both URLs are public or private
-// from the same URL.
+// CompareMirrorURL will return true if a style is being imported and mirrored,
+// and both URLs are public or private from the same URL.
 func (s *APIStyle) CompareMirrorURL() bool {
 	if s.Original != "" &&
 		(s.MirrorCode || s.MirrorMeta) &&
-		(s.MirrorURL == "" || s.MirrorURL == s.Original) { /*&&
-		!(s.ImportPrivate || s.MirrorPrivate)*/
+		(s.MirrorURL == "" || s.MirrorURL == s.Original) {
 		return true
 	}
 

--- a/models/style.go
+++ b/models/style.go
@@ -373,7 +373,7 @@ func (s *APIStyle) HeadlineText() string {
 	var res string
 	switch {
 	case s.CompareMirrorURL() && !(s.ImportPrivate || s.MirrorPrivate):
-		res = fmt.Sprintf("<p class=\"mb:m md\">Imported and mirrored code from <code>%s</code>.</p>", s.Original)
+		res = fmt.Sprintf("<p class=\"mb:m md\">Imported and mirrored from <code>%s</code></p>", s.Original)
 
 	case s.ImportPrivate || s.MirrorPrivate:
 		if s.Original != "" {
@@ -381,31 +381,22 @@ func (s *APIStyle) HeadlineText() string {
 			if !s.ImportPrivate {
 				res += fmt.Sprintf(" from <code>%s</code>", s.Original)
 			}
-			if s.IsMirrored() {
-				res += ",</p> "
-			} else {
-				res += ".</p>"
-			}
+			res += "</p>"
 		}
 		if s.IsMirrored() {
 			res += "<p class=\"mb:m md\">Mirrored"
 			if !s.MirrorPrivate {
 				res += fmt.Sprintf(" from <code>%s</code>", s.MirrorURL)
 			}
-			res += ".</p>"
+			res += "</p>"
 		}
 
 	default:
 		if s.Original != "" {
-			res = fmt.Sprintf("<p class=\"mb:m md\">Imported from <code>%s</code>", s.Original)
-			if s.IsMirrored() {
-				res += ",</p> "
-			} else {
-				res += ".</p>"
-			}
+			res = fmt.Sprintf("<p class=\"mb:m md\">Imported from <code>%s</code></p>", s.Original)
 		}
 		if s.IsMirrored() {
-			res += fmt.Sprintf("<p class=\"mb:m md\">Mirrored from <code>%s</code>.</p>", s.MirrorURL)
+			res += fmt.Sprintf("<p class=\"mb:m md\">Mirrored from <code>%s</code></p>", s.MirrorURL)
 		}
 	}
 

--- a/models/style.go
+++ b/models/style.go
@@ -351,8 +351,7 @@ func SelectUpdateStyle(s Style) error {
 func (s *APIStyle) CompareMirrorURL() bool {
 	if s.Original != "" &&
 		(s.MirrorCode || s.MirrorMeta) &&
-		(s.MirrorURL == "" || s.MirrorURL == s.Original) &&
-		!(s.ImportPrivate || s.MirrorPrivate) {
+		(s.MirrorURL == "" || s.MirrorURL == s.Original) {
 		return true
 	}
 
@@ -360,6 +359,9 @@ func (s *APIStyle) CompareMirrorURL() bool {
 }
 
 func (s *APIStyle) ImportedAndMirroredText() string {
+	if s.ImportPrivate || s.MirrorPrivate {
+		return "Imported and mirrored from a private source"
+	}
 	return "Imported and mirrored from <code>" + s.Original + "</code>"
 }
 
@@ -372,16 +374,15 @@ func (s *APIStyle) MirroredCondition() bool {
 }
 
 func (s *APIStyle) ImportedText() string {
-	return "Imported from " + ternary(s.ImportPrivate, "private source", "<code>"+s.Original+"</code>")
+	if s.ImportPrivate {
+		return "Imported from a private source"
+	}
+	return "Imported from <code>" + s.Original + "</code>"
 }
 
 func (s *APIStyle) MirroredText() string {
-	return "Mirrored from " + ternary(s.MirrorPrivate, "private source", "<code>"+s.MirrorURL+"</code>")
-}
-
-func ternary(what bool, truetext string, falsetext string) string {
-	if what {
-		return truetext
+	if s.MirrorPrivate {
+		return "Mirrored from a private source"
 	}
-	return falsetext
+	return "Mirrored from <code>" + s.MirrorURL + "</code>"
 }

--- a/models/style_test.go
+++ b/models/style_test.go
@@ -12,6 +12,15 @@ func TestAPIStyle_ImportedAndMirrored(t *testing.T) {
 		mirrored string
 	}{
 		{
+			name: "mirrored import public",
+			input: APIStyle{
+				Original:   "x",
+				MirrorCode: true,
+			},
+			branch:   true,
+			combined: "Imported and mirrored from <code>x</code>",
+		},
+		{
 			name: "mirrored import private due to import",
 			input: APIStyle{
 				Original:      "x",
@@ -22,23 +31,24 @@ func TestAPIStyle_ImportedAndMirrored(t *testing.T) {
 			combined: "Imported and mirrored from a private source",
 		},
 		{
-			name: "mirrored import public",
+			name: "mirrored import private due to mirror",
+			input: APIStyle{
+				Original:      "x",
+				MirrorPrivate: true,
+				MirrorCode:    true,
+			},
+			branch:   true,
+			combined: "Imported and mirrored from a private source",
+		},
+		{
+			name: "both public",
 			input: APIStyle{
 				Original:   "x",
+				MirrorURL:  "x",
 				MirrorCode: true,
 			},
 			branch:   true,
 			combined: "Imported and mirrored from <code>x</code>",
-		},
-		{
-			name: "mirrored import private due to mirror",
-			input: APIStyle{
-				Original:      "x",
-				MirrorCode:    true,
-				MirrorPrivate: true,
-			},
-			branch:   true,
-			combined: "Imported and mirrored from a private source",
 		},
 		{
 			name: "both private due to import",
@@ -52,58 +62,47 @@ func TestAPIStyle_ImportedAndMirrored(t *testing.T) {
 			combined: "Imported and mirrored from a private source",
 		},
 		{
-			name: "both public",
-			input: APIStyle{
-				Original:   "x",
-				MirrorCode: true,
-				MirrorURL:  "x",
-			},
-			branch:   true,
-			combined: "Imported and mirrored from <code>x</code>",
-		},
-		{
 			name: "both private due to mirror",
 			input: APIStyle{
 				Original:      "x",
 				MirrorURL:     "x",
-				MirrorCode:    true,
 				MirrorPrivate: true,
+				MirrorCode:    true,
 			},
 			branch:   true,
 			combined: "Imported and mirrored from a private source",
 		},
 		{
-			name: "different URLs private",
-			input: APIStyle{
-				Original:      "x",
-				ImportPrivate: true,
-				MirrorCode:    true,
-				MirrorURL:     "y",
-				MirrorPrivate: true,
-			},
-			branch:   false,
-			imported: "Imported from a private source",
-			mirrored: "Mirrored from a private source",
-		},
-		{
 			name: "different URLs public",
 			input: APIStyle{
 				Original:   "x",
-				MirrorCode: true,
 				MirrorURL:  "y",
+				MirrorCode: true,
 			},
 			branch:   false,
 			imported: "Imported from <code>x</code>",
 			mirrored: "Mirrored from <code>y</code>",
 		},
 		{
+			name: "different URLs private",
+			input: APIStyle{
+				Original:      "x",
+				ImportPrivate: true,
+				MirrorURL:     "y",
+				MirrorPrivate: true,
+				MirrorCode:    true,
+			},
+			branch:   false,
+			imported: "Imported from a private source",
+			mirrored: "Mirrored from a private source",
+		},
+		{
 			name: "different URLs private import",
 			input: APIStyle{
 				Original:      "x",
 				ImportPrivate: true,
-				MirrorCode:    true,
 				MirrorURL:     "y",
-				MirrorPrivate: false,
+				MirrorCode:    true,
 			},
 			branch:   false,
 			imported: "Imported from a private source",
@@ -113,10 +112,9 @@ func TestAPIStyle_ImportedAndMirrored(t *testing.T) {
 			name: "different URLs private mirror",
 			input: APIStyle{
 				Original:      "x",
-				ImportPrivate: false,
-				MirrorCode:    true,
 				MirrorURL:     "y",
 				MirrorPrivate: true,
+				MirrorCode:    true,
 			},
 			branch:   false,
 			imported: "Imported from <code>x</code>",
@@ -159,19 +157,19 @@ func TestAPIStyle_Imported(t *testing.T) {
 		expected string
 	}{
 		{
+			name: "public",
+			input: APIStyle{
+				Original: "x",
+			},
+			expected: "Imported from <code>x</code>",
+		},
+		{
 			name: "private",
 			input: APIStyle{
 				Original:      "x",
 				ImportPrivate: true,
 			},
 			expected: "Imported from a private source",
-		},
-		{
-			name: "public",
-			input: APIStyle{
-				Original: "x",
-			},
-			expected: "Imported from <code>x</code>",
 		},
 	}
 
@@ -195,21 +193,21 @@ func TestAPIStyle_Mirrored(t *testing.T) {
 		expected string
 	}{
 		{
-			name: "private",
-			input: APIStyle{
-				MirrorURL:     "x",
-				MirrorCode:    true,
-				MirrorPrivate: true,
-			},
-			expected: "Mirrored from a private source",
-		},
-		{
 			name: "public",
 			input: APIStyle{
 				MirrorURL:  "x",
 				MirrorCode: true,
 			},
 			expected: "Mirrored from <code>x</code>",
+		},
+		{
+			name: "private",
+			input: APIStyle{
+				MirrorURL:     "x",
+				MirrorPrivate: true,
+				MirrorCode:    true,
+			},
+			expected: "Mirrored from a private source",
 		},
 	}
 

--- a/models/style_test.go
+++ b/models/style_test.go
@@ -2,91 +2,133 @@ package models
 
 import "testing"
 
-func TestStyle(t *testing.T) {
+func TestAPIStyle_CompareMirrorURL(t *testing.T) {
 	cases := []struct {
 		name     string
 		input    APIStyle
 		expected string
 	}{
 		{
-			name: "imported",
+			name: "private import",
 			input: APIStyle{
 				Original:      "x",
+				MirrorCode:    true,
 				ImportPrivate: true,
 			},
-			expected: "<p class=\"mb:m md\">Imported</p>",
+			expected: "Imported and mirrored from a private source",
 		},
 		{
-			name: "imported from x",
-			input: APIStyle{
-				Original: "x",
-			},
-			expected: "<p class=\"mb:m md\">Imported from <code>x</code></p>",
-		},
-		{
-			name: "mirrored",
-			input: APIStyle{
-				MirrorURL:     "x",
-				MirrorCode:    true,
-				MirrorPrivate: true,
-			},
-			expected: "<p class=\"mb:m md\">Mirrored</p>",
-		},
-		{
-			name: "mirrored from x",
-			input: APIStyle{
-				MirrorURL:  "x",
-				MirrorCode: true,
-			},
-			expected: "<p class=\"mb:m md\">Mirrored from <code>x</code></p>",
-		},
-		{
-			name: "imported and mirrored",
-			input: APIStyle{
-				Original:      "x",
-				ImportPrivate: true,
-				MirrorURL:     "y",
-				MirrorCode:    true,
-				MirrorPrivate: true,
-			},
-			expected: "<p class=\"mb:m md\">Imported</p><p class=\"mb:m md\">Mirrored</p>",
-		},
-		{
-			name: "imported from x and mirrored",
-			input: APIStyle{
-				Original:      "x",
-				MirrorURL:     "y",
-				MirrorCode:    true,
-				MirrorPrivate: true,
-			},
-			expected: "<p class=\"mb:m md\">Imported from <code>x</code></p><p class=\"mb:m md\">Mirrored</p>",
-		},
-		{
-			name: "imported and mirrored from x",
-			input: APIStyle{
-				Original:      "x",
-				ImportPrivate: true,
-				MirrorURL:     "y",
-				MirrorCode:    true,
-			},
-			expected: "<p class=\"mb:m md\">Imported</p><p class=\"mb:m md\">Mirrored from <code>y</code></p>",
-		},
-		{
-			name: "imported from x and mirrored from x",
+			name: "public origin",
 			input: APIStyle{
 				Original:   "x",
-				MirrorURL:  "y",
 				MirrorCode: true,
 			},
-			expected: "<p class=\"mb:m md\">Imported from <code>x</code></p><p class=\"mb:m md\">Mirrored from <code>y</code></p>",
+			expected: "Imported and mirrored from <code>x</code>",
+		},
+		{
+			name: "both private",
+			input: APIStyle{
+				Original:      "x",
+				ImportPrivate: true,
+				MirrorURL:     "x",
+				MirrorCode:    true,
+				MirrorPrivate: false,
+			},
+			expected: "Imported and mirrored from a private source",
+		},
+		{
+			name: "both public",
+			input: APIStyle{
+				Original:   "x",
+				MirrorCode: true,
+				MirrorURL:  "x",
+			},
+			expected: "Imported and mirrored from <code>x</code>",
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := "pleasefixtests"; got != c.expected {
-				t.Errorf("got: %s\n", got)
-				t.Errorf("exp: %s\n", c.expected)
+			if !c.input.CompareMirrorURL() {
+				t.Fatal("import and mirror URL don't match")
+			}
+			if got := c.input.ImportedAndMirroredText(); got != c.expected {
+				t.Errorf("got: %v\n", got)
+				t.Errorf("exp: %v\n", c.expected)
+			}
+		})
+	}
+}
+
+func TestAPIStyle_ImportedCondition(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    APIStyle
+		expected string
+	}{
+		{
+			name: "imported private",
+			input: APIStyle{
+				Original:      "x",
+				ImportPrivate: true,
+			},
+			expected: "Imported from a private source",
+		},
+		{
+			name: "imported public",
+			input: APIStyle{
+				Original: "x",
+			},
+			expected: "Imported from <code>x</code>",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if !c.input.ImportedCondition() {
+				t.Errorf("style isn't imported")
+			}
+			if got := c.input.ImportedText(); got != c.expected {
+				t.Errorf("got: %v\n", got)
+				t.Errorf("exp: %v\n", c.expected)
+			}
+		})
+	}
+}
+
+func TestAPIStyle_MirroredCondition(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    APIStyle
+		expected string
+	}{
+		{
+			name: "mirrored private",
+			input: APIStyle{
+				MirrorURL:     "x",
+				MirrorCode:    true,
+				MirrorPrivate: true,
+			},
+			expected: "Mirrored from a private source",
+		},
+		{
+			name: "mirrored public",
+			input: APIStyle{
+				MirrorURL:  "x",
+				MirrorCode: true,
+			},
+			expected: "Mirrored from <code>x</code>",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if !c.input.MirroredCondition() {
+				t.Errorf("style isn't mirrored")
+			}
+			if got := c.input.MirroredText(); got != c.expected {
+				t.Errorf("got: %v\n", got)
+				t.Errorf("exp: %v\n", c.expected)
 			}
 		})
 	}

--- a/models/style_test.go
+++ b/models/style_test.go
@@ -12,17 +12,17 @@ func TestAPIStyle_ImportedAndMirrored(t *testing.T) {
 		mirrored string
 	}{
 		{
-			name: "private import",
+			name: "mirrored import private due to import",
 			input: APIStyle{
 				Original:      "x",
-				MirrorCode:    true,
 				ImportPrivate: true,
+				MirrorCode:    true,
 			},
 			branch:   true,
 			combined: "Imported and mirrored from a private source",
 		},
 		{
-			name: "public origin",
+			name: "mirrored import public",
 			input: APIStyle{
 				Original:   "x",
 				MirrorCode: true,
@@ -31,13 +31,22 @@ func TestAPIStyle_ImportedAndMirrored(t *testing.T) {
 			combined: "Imported and mirrored from <code>x</code>",
 		},
 		{
-			name: "both private",
+			name: "mirrored import private due to mirror",
+			input: APIStyle{
+				Original:      "x",
+				MirrorCode:    true,
+				MirrorPrivate: true,
+			},
+			branch:   true,
+			combined: "Imported and mirrored from a private source",
+		},
+		{
+			name: "both private due to import",
 			input: APIStyle{
 				Original:      "x",
 				ImportPrivate: true,
 				MirrorURL:     "x",
 				MirrorCode:    true,
-				MirrorPrivate: false,
 			},
 			branch:   true,
 			combined: "Imported and mirrored from a private source",
@@ -51,6 +60,17 @@ func TestAPIStyle_ImportedAndMirrored(t *testing.T) {
 			},
 			branch:   true,
 			combined: "Imported and mirrored from <code>x</code>",
+		},
+		{
+			name: "both private due to mirror",
+			input: APIStyle{
+				Original:      "x",
+				MirrorURL:     "x",
+				MirrorCode:    true,
+				MirrorPrivate: true,
+			},
+			branch:   true,
+			combined: "Imported and mirrored from a private source",
 		},
 		{
 			name: "different URLs private",

--- a/models/style_test.go
+++ b/models/style_test.go
@@ -2,146 +2,146 @@ package models
 
 import "testing"
 
-func TestAPIStyle_ImportedAndMirrored(t *testing.T) {
-	cases := []struct {
-		name     string
-		input    APIStyle
-		branch   bool
-		combined string
-		imported string
-		mirrored string
-	}{
-		{
-			name: "mirrored import public",
-			input: APIStyle{
-				Original:   "x",
-				MirrorCode: true,
-			},
-			branch:   true,
-			combined: "Imported and mirrored from <code>x</code>",
+var importAndMirrorCases = []struct {
+	name     string
+	input    APIStyle
+	branch   bool
+	combined string
+	imported string
+	mirrored string
+}{
+	{
+		name: "mirrored import public",
+		input: APIStyle{
+			Original:   "x",
+			MirrorCode: true,
 		},
-		{
-			name: "mirrored import private due to import",
-			input: APIStyle{
-				Original:      "x",
-				ImportPrivate: true,
-				MirrorCode:    true,
-			},
-			branch:   true,
-			combined: "Imported and mirrored from a private source",
+		branch:   true,
+		combined: "Imported and mirrored from <code>x</code>",
+	},
+	{
+		name: "mirrored import private due to import",
+		input: APIStyle{
+			Original:      "x",
+			ImportPrivate: true,
+			MirrorCode:    true,
 		},
-		{
-			name: "mirrored import private due to mirror",
-			input: APIStyle{
-				Original:      "x",
-				MirrorPrivate: true,
-				MirrorCode:    true,
-			},
-			branch:   true,
-			combined: "Imported and mirrored from a private source",
+		branch:   true,
+		combined: "Imported and mirrored from a private source",
+	},
+	{
+		name: "mirrored import private due to mirror",
+		input: APIStyle{
+			Original:      "x",
+			MirrorPrivate: true,
+			MirrorCode:    true,
 		},
-		{
-			name: "both public",
-			input: APIStyle{
-				Original:   "x",
-				MirrorURL:  "x",
-				MirrorCode: true,
-			},
-			branch:   true,
-			combined: "Imported and mirrored from <code>x</code>",
+		branch:   true,
+		combined: "Imported and mirrored from a private source",
+	},
+	{
+		name: "both public",
+		input: APIStyle{
+			Original:   "x",
+			MirrorURL:  "x",
+			MirrorCode: true,
 		},
-		{
-			name: "both private due to import",
-			input: APIStyle{
-				Original:      "x",
-				ImportPrivate: true,
-				MirrorURL:     "x",
-				MirrorCode:    true,
-			},
-			branch:   true,
-			combined: "Imported and mirrored from a private source",
+		branch:   true,
+		combined: "Imported and mirrored from <code>x</code>",
+	},
+	{
+		name: "both private due to import",
+		input: APIStyle{
+			Original:      "x",
+			ImportPrivate: true,
+			MirrorURL:     "x",
+			MirrorCode:    true,
 		},
-		{
-			name: "both private due to mirror",
-			input: APIStyle{
-				Original:      "x",
-				MirrorURL:     "x",
-				MirrorPrivate: true,
-				MirrorCode:    true,
-			},
-			branch:   true,
-			combined: "Imported and mirrored from a private source",
+		branch:   true,
+		combined: "Imported and mirrored from a private source",
+	},
+	{
+		name: "both private due to mirror",
+		input: APIStyle{
+			Original:      "x",
+			MirrorURL:     "x",
+			MirrorPrivate: true,
+			MirrorCode:    true,
 		},
-		{
-			name: "different URLs public",
-			input: APIStyle{
-				Original:   "x",
-				MirrorURL:  "y",
-				MirrorCode: true,
-			},
-			branch:   false,
-			imported: "Imported from <code>x</code>",
-			mirrored: "Mirrored from <code>y</code>",
+		branch:   true,
+		combined: "Imported and mirrored from a private source",
+	},
+	{
+		name: "different URLs public",
+		input: APIStyle{
+			Original:   "x",
+			MirrorURL:  "y",
+			MirrorCode: true,
 		},
-		{
-			name: "different URLs private",
-			input: APIStyle{
-				Original:      "x",
-				ImportPrivate: true,
-				MirrorURL:     "y",
-				MirrorPrivate: true,
-				MirrorCode:    true,
-			},
-			branch:   false,
-			imported: "Imported from a private source",
-			mirrored: "Mirrored from a private source",
+		branch:   false,
+		imported: "Imported from <code>x</code>",
+		mirrored: "Mirrored from <code>y</code>",
+	},
+	{
+		name: "different URLs private",
+		input: APIStyle{
+			Original:      "x",
+			ImportPrivate: true,
+			MirrorURL:     "y",
+			MirrorPrivate: true,
+			MirrorCode:    true,
 		},
-		{
-			name: "different URLs private import",
-			input: APIStyle{
-				Original:      "x",
-				ImportPrivate: true,
-				MirrorURL:     "y",
-				MirrorCode:    true,
-			},
-			branch:   false,
-			imported: "Imported from a private source",
-			mirrored: "Mirrored from <code>y</code>",
+		branch:   false,
+		imported: "Imported from a private source",
+		mirrored: "Mirrored from a private source",
+	},
+	{
+		name: "different URLs private import",
+		input: APIStyle{
+			Original:      "x",
+			ImportPrivate: true,
+			MirrorURL:     "y",
+			MirrorCode:    true,
 		},
-		{
-			name: "different URLs private mirror",
-			input: APIStyle{
-				Original:      "x",
-				MirrorURL:     "y",
-				MirrorPrivate: true,
-				MirrorCode:    true,
-			},
-			branch:   false,
-			imported: "Imported from <code>x</code>",
-			mirrored: "Mirrored from a private source",
+		branch:   false,
+		imported: "Imported from a private source",
+		mirrored: "Mirrored from <code>y</code>",
+	},
+	{
+		name: "different URLs private mirror",
+		input: APIStyle{
+			Original:      "x",
+			MirrorURL:     "y",
+			MirrorPrivate: true,
+			MirrorCode:    true,
 		},
-		{
-			name: "has import URL but not mirrored",
-			input: APIStyle{
-				Original: "x",
-			},
-			branch:   false,
-			imported: "Imported from <code>x</code>",
+		branch:   false,
+		imported: "Imported from <code>x</code>",
+		mirrored: "Mirrored from a private source",
+	},
+	{
+		name: "has import URL but not mirrored",
+		input: APIStyle{
+			Original: "x",
 		},
-		{
-			name: "has mirror URL but not mirrored",
-			input: APIStyle{
-				MirrorURL: "y",
-			},
-			branch: false,
+		branch:   false,
+		imported: "Imported from <code>x</code>",
+	},
+	{
+		name: "has mirror URL but not mirrored",
+		input: APIStyle{
+			MirrorURL: "y",
 		},
-		{
-			name:  "empty",
-			input: APIStyle{},
-		},
-	}
+		branch: false,
+	},
+	{
+		name:  "empty",
+		input: APIStyle{},
+	},
+}
 
-	for _, c := range cases {
+func TestAPIStyle_ImportedAndMirrored(t *testing.T) {
+	for _, c := range importAndMirrorCases {
 		t.Run(c.name, func(t *testing.T) {
 			if c.input.ImportedAndMirrored() != c.branch {
 				t.Fatal("import and mirror URL should match")
@@ -166,6 +166,27 @@ func TestAPIStyle_ImportedAndMirrored(t *testing.T) {
 					if got != c.mirrored {
 						t.Errorf("got: %v\n", got)
 						t.Errorf("exp: %v\n", c.mirrored)
+					}
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkAPIStyle_ImportedAndMirrored(b *testing.B) {
+	for _, c := range importAndMirrorCases {
+		b.Run(c.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				if c.branch {
+					if c.input.ImportedAndMirrored() {
+						c.input.ImportedAndMirroredText()
+					}
+				} else {
+					if c.input.Imported() {
+						c.input.ImportedText()
+					}
+					if c.input.Mirrored() {
+						c.input.MirroredText()
 					}
 				}
 			}

--- a/models/style_test.go
+++ b/models/style_test.go
@@ -1,0 +1,93 @@
+package models
+
+import "testing"
+
+func TestStyle(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    APIStyle
+		expected string
+	}{
+		{
+			name: "imported",
+			input: APIStyle{
+				Original:      "x",
+				ImportPrivate: true,
+			},
+			expected: "Imported.",
+		},
+		{
+			name: "imported from x",
+			input: APIStyle{
+				Original: "x",
+			},
+			expected: "Imported from <code>x</code>.",
+		},
+		{
+			name: "mirrored",
+			input: APIStyle{
+				MirrorURL:     "x",
+				MirrorCode:    true,
+				MirrorPrivate: true,
+			},
+			expected: "Mirrored.",
+		},
+		{
+			name: "mirrored from x",
+			input: APIStyle{
+				MirrorURL:  "x",
+				MirrorCode: true,
+			},
+			expected: "<nobr>Mirrored from <code>x</code>.</nobr>",
+		},
+		{
+			name: "imported and mirrored",
+			input: APIStyle{
+				Original:      "x",
+				ImportPrivate: true,
+				MirrorURL:     "y",
+				MirrorCode:    true,
+				MirrorPrivate: true,
+			},
+			expected: "Imported, Mirrored.",
+		},
+		{
+			name: "imported from x and mirrored",
+			input: APIStyle{
+				Original:      "x",
+				MirrorURL:     "y",
+				MirrorCode:    true,
+				MirrorPrivate: true,
+			},
+			expected: "Imported from <code>x</code>, Mirrored.",
+		},
+		{
+			name: "imported and mirrored from x",
+			input: APIStyle{
+				Original:      "x",
+				ImportPrivate: true,
+				MirrorURL:     "y",
+				MirrorCode:    true,
+			},
+			expected: "Imported, Mirrored from <code>y</code>.",
+		},
+		{
+			name: "imported from x and mirrored from x",
+			input: APIStyle{
+				Original:   "x",
+				MirrorURL:  "y",
+				MirrorCode: true,
+			},
+			expected: "Imported from <code>x</code>, <nobr>Mirrored from <code>y</code>.</nobr>",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.input.HeadlineText(); got != c.expected {
+				t.Errorf("got: %s\n", got)
+				t.Errorf("exp: %s\n", c.expected)
+			}
+		})
+	}
+}

--- a/models/style_test.go
+++ b/models/style_test.go
@@ -2,7 +2,7 @@ package models
 
 import "testing"
 
-func TestAPIStyle_CompareMirrorURL(t *testing.T) {
+func TestAPIStyle_ImportedAndMirrored(t *testing.T) {
 	cases := []struct {
 		name     string
 		input    APIStyle
@@ -49,7 +49,7 @@ func TestAPIStyle_CompareMirrorURL(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if !c.input.CompareMirrorURL() {
+			if !c.input.ImportedAndMirrored() {
 				t.Fatal("import and mirror URL don't match")
 			}
 			if got := c.input.ImportedAndMirroredText(); got != c.expected {
@@ -60,14 +60,14 @@ func TestAPIStyle_CompareMirrorURL(t *testing.T) {
 	}
 }
 
-func TestAPIStyle_ImportedCondition(t *testing.T) {
+func TestAPIStyle_Imported(t *testing.T) {
 	cases := []struct {
 		name     string
 		input    APIStyle
 		expected string
 	}{
 		{
-			name: "imported private",
+			name: "private",
 			input: APIStyle{
 				Original:      "x",
 				ImportPrivate: true,
@@ -75,7 +75,7 @@ func TestAPIStyle_ImportedCondition(t *testing.T) {
 			expected: "Imported from a private source",
 		},
 		{
-			name: "imported public",
+			name: "public",
 			input: APIStyle{
 				Original: "x",
 			},
@@ -85,7 +85,7 @@ func TestAPIStyle_ImportedCondition(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if !c.input.ImportedCondition() {
+			if !c.input.Imported() {
 				t.Errorf("style isn't imported")
 			}
 			if got := c.input.ImportedText(); got != c.expected {
@@ -96,14 +96,14 @@ func TestAPIStyle_ImportedCondition(t *testing.T) {
 	}
 }
 
-func TestAPIStyle_MirroredCondition(t *testing.T) {
+func TestAPIStyle_Mirrored(t *testing.T) {
 	cases := []struct {
 		name     string
 		input    APIStyle
 		expected string
 	}{
 		{
-			name: "mirrored private",
+			name: "private",
 			input: APIStyle{
 				MirrorURL:     "x",
 				MirrorCode:    true,
@@ -112,7 +112,7 @@ func TestAPIStyle_MirroredCondition(t *testing.T) {
 			expected: "Mirrored from a private source",
 		},
 		{
-			name: "mirrored public",
+			name: "public",
 			input: APIStyle{
 				MirrorURL:  "x",
 				MirrorCode: true,
@@ -123,7 +123,7 @@ func TestAPIStyle_MirroredCondition(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if !c.input.MirroredCondition() {
+			if !c.input.Mirrored() {
 				t.Errorf("style isn't mirrored")
 			}
 			if got := c.input.MirroredText(); got != c.expected {

--- a/models/style_test.go
+++ b/models/style_test.go
@@ -120,6 +120,25 @@ func TestAPIStyle_ImportedAndMirrored(t *testing.T) {
 			imported: "Imported from <code>x</code>",
 			mirrored: "Mirrored from a private source",
 		},
+		{
+			name: "has import URL but not mirrored",
+			input: APIStyle{
+				Original: "x",
+			},
+			branch:   false,
+			imported: "Imported from <code>x</code>",
+		},
+		{
+			name: "has mirror URL but not mirrored",
+			input: APIStyle{
+				MirrorURL: "y",
+			},
+			branch: false,
+		},
+		{
+			name:  "empty",
+			input: APIStyle{},
+		},
 	}
 
 	for _, c := range cases {
@@ -135,15 +154,19 @@ func TestAPIStyle_ImportedAndMirrored(t *testing.T) {
 					t.Errorf("exp: %v\n", c.combined)
 				}
 			} else {
-				got := c.input.ImportedText()
-				if got != c.imported {
-					t.Errorf("got: %v\n", got)
-					t.Errorf("exp: %v\n", c.imported)
+				if c.input.Imported() {
+					got := c.input.ImportedText()
+					if got != c.imported {
+						t.Errorf("got: %v\n", got)
+						t.Errorf("exp: %v\n", c.imported)
+					}
 				}
-				got = c.input.MirroredText()
-				if got != c.mirrored {
-					t.Errorf("got: %v\n", got)
-					t.Errorf("exp: %v\n", c.mirrored)
+				if c.input.Mirrored() {
+					got := c.input.MirroredText()
+					if got != c.mirrored {
+						t.Errorf("got: %v\n", got)
+						t.Errorf("exp: %v\n", c.mirrored)
+					}
 				}
 			}
 		})

--- a/models/style_test.go
+++ b/models/style_test.go
@@ -14,14 +14,14 @@ func TestStyle(t *testing.T) {
 				Original:      "x",
 				ImportPrivate: true,
 			},
-			expected: "Imported.",
+			expected: "<p class=\"mb:m md\">Imported.</p>",
 		},
 		{
 			name: "imported from x",
 			input: APIStyle{
 				Original: "x",
 			},
-			expected: "Imported from <code>x</code>.",
+			expected: "<p class=\"mb:m md\">Imported from <code>x</code>.</p>",
 		},
 		{
 			name: "mirrored",
@@ -30,7 +30,7 @@ func TestStyle(t *testing.T) {
 				MirrorCode:    true,
 				MirrorPrivate: true,
 			},
-			expected: "Mirrored.",
+			expected: "<p class=\"mb:m md\">Mirrored.</p>",
 		},
 		{
 			name: "mirrored from x",
@@ -38,7 +38,7 @@ func TestStyle(t *testing.T) {
 				MirrorURL:  "x",
 				MirrorCode: true,
 			},
-			expected: "<nobr>Mirrored from <code>x</code>.</nobr>",
+			expected: "<p class=\"mb:m md\">Mirrored from <code>x</code>.</p>",
 		},
 		{
 			name: "imported and mirrored",
@@ -49,7 +49,7 @@ func TestStyle(t *testing.T) {
 				MirrorCode:    true,
 				MirrorPrivate: true,
 			},
-			expected: "Imported, Mirrored.",
+			expected: "<p class=\"mb:m md\">Imported</p>, <p class=\"mb:m md\">Mirrored.</p>",
 		},
 		{
 			name: "imported from x and mirrored",
@@ -59,7 +59,7 @@ func TestStyle(t *testing.T) {
 				MirrorCode:    true,
 				MirrorPrivate: true,
 			},
-			expected: "Imported from <code>x</code>, Mirrored.",
+			expected: "<p class=\"mb:m md\">Imported from <code>x</code>,</p> <p class=\"mb:m md\">Mirrored.</p>",
 		},
 		{
 			name: "imported and mirrored from x",
@@ -69,7 +69,7 @@ func TestStyle(t *testing.T) {
 				MirrorURL:     "y",
 				MirrorCode:    true,
 			},
-			expected: "Imported, Mirrored from <code>y</code>.",
+			expected: "<p class=\"mb:m md\">Imported,</p> <p class=\"mb:m md\">Mirrored from <code>y</code>.</p>",
 		},
 		{
 			name: "imported from x and mirrored from x",
@@ -78,7 +78,7 @@ func TestStyle(t *testing.T) {
 				MirrorURL:  "y",
 				MirrorCode: true,
 			},
-			expected: "Imported from <code>x</code>, <nobr>Mirrored from <code>y</code>.</nobr>",
+			expected: "<p class=\"mb:m md\">Imported from <code>x</code>,</p> <p class=\"mb:m md\">Mirrored from <code>y</code>.</p>",
 		},
 	}
 

--- a/models/style_test.go
+++ b/models/style_test.go
@@ -84,7 +84,7 @@ func TestStyle(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := c.input.HeadlineText(); got != c.expected {
+			if got := "pleasefixtests"; got != c.expected {
 				t.Errorf("got: %s\n", got)
 				t.Errorf("exp: %s\n", c.expected)
 			}

--- a/models/style_test.go
+++ b/models/style_test.go
@@ -143,30 +143,25 @@ var importAndMirrorCases = []struct {
 func TestAPIStyle_ImportedAndMirrored(t *testing.T) {
 	for _, c := range importAndMirrorCases {
 		t.Run(c.name, func(t *testing.T) {
-			if c.input.ImportedAndMirrored() != c.branch {
-				t.Fatal("import and mirror URL should match")
-			}
-
 			if c.branch {
-				got := c.input.ImportedAndMirroredText()
-				if got != c.combined {
-					t.Errorf("got: %v\n", got)
-					t.Errorf("exp: %v\n", c.combined)
+				combined := c.input.ImportedAndMirrored()
+				if combined != c.combined {
+					t.Errorf("combined: %v\n", combined)
+					t.Errorf("expected: %v\n", c.combined)
 				}
 			} else {
-				if c.input.Imported() {
-					got := c.input.ImportedText()
-					if got != c.imported {
-						t.Errorf("got: %v\n", got)
-						t.Errorf("exp: %v\n", c.imported)
-					}
+				if c.input.isImportedAndMirrored() {
+					t.Fatal("import and mirror URL should match")
 				}
-				if c.input.Mirrored() {
-					got := c.input.MirroredText()
-					if got != c.mirrored {
-						t.Errorf("got: %v\n", got)
-						t.Errorf("exp: %v\n", c.mirrored)
-					}
+				imported := c.input.Imported()
+				if imported != c.imported {
+					t.Errorf("imported: %v\n", imported)
+					t.Errorf("expected: %v\n", c.imported)
+				}
+				mirrored := c.input.Mirrored()
+				if mirrored != c.mirrored {
+					t.Errorf("mirrored: %v\n", mirrored)
+					t.Errorf("expected: %v\n", c.mirrored)
 				}
 			}
 		})
@@ -178,16 +173,10 @@ func BenchmarkAPIStyle_ImportedAndMirrored(b *testing.B) {
 		b.Run(c.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				if c.branch {
-					if c.input.ImportedAndMirrored() {
-						c.input.ImportedAndMirroredText()
-					}
+					c.input.ImportedAndMirrored()
 				} else {
-					if c.input.Imported() {
-						c.input.ImportedText()
-					}
-					if c.input.Mirrored() {
-						c.input.MirroredText()
-					}
+					c.input.Imported()
+					c.input.Mirrored()
 				}
 			}
 		})
@@ -219,10 +208,10 @@ func TestAPIStyle_Imported(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if !c.input.Imported() {
+			if !c.input.isImported() {
 				t.Fatal("style isn't imported")
 			}
-			if got := c.input.ImportedText(); got != c.expected {
+			if got := c.input.Imported(); got != c.expected {
 				t.Errorf("got: %v\n", got)
 				t.Errorf("exp: %v\n", c.expected)
 			}
@@ -257,10 +246,10 @@ func TestAPIStyle_Mirrored(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if !c.input.Mirrored() {
+			if !c.input.isMirrored() {
 				t.Fatal("style isn't mirrored")
 			}
-			if got := c.input.MirroredText(); got != c.expected {
+			if got := c.input.Mirrored(); got != c.expected {
 				t.Errorf("got: %v\n", got)
 				t.Errorf("exp: %v\n", c.expected)
 			}

--- a/models/style_test.go
+++ b/models/style_test.go
@@ -14,14 +14,14 @@ func TestStyle(t *testing.T) {
 				Original:      "x",
 				ImportPrivate: true,
 			},
-			expected: "<p class=\"mb:m md\">Imported.</p>",
+			expected: "<p class=\"mb:m md\">Imported</p>",
 		},
 		{
 			name: "imported from x",
 			input: APIStyle{
 				Original: "x",
 			},
-			expected: "<p class=\"mb:m md\">Imported from <code>x</code>.</p>",
+			expected: "<p class=\"mb:m md\">Imported from <code>x</code></p>",
 		},
 		{
 			name: "mirrored",
@@ -30,7 +30,7 @@ func TestStyle(t *testing.T) {
 				MirrorCode:    true,
 				MirrorPrivate: true,
 			},
-			expected: "<p class=\"mb:m md\">Mirrored.</p>",
+			expected: "<p class=\"mb:m md\">Mirrored</p>",
 		},
 		{
 			name: "mirrored from x",
@@ -38,7 +38,7 @@ func TestStyle(t *testing.T) {
 				MirrorURL:  "x",
 				MirrorCode: true,
 			},
-			expected: "<p class=\"mb:m md\">Mirrored from <code>x</code>.</p>",
+			expected: "<p class=\"mb:m md\">Mirrored from <code>x</code></p>",
 		},
 		{
 			name: "imported and mirrored",
@@ -49,7 +49,7 @@ func TestStyle(t *testing.T) {
 				MirrorCode:    true,
 				MirrorPrivate: true,
 			},
-			expected: "<p class=\"mb:m md\">Imported</p>, <p class=\"mb:m md\">Mirrored.</p>",
+			expected: "<p class=\"mb:m md\">Imported</p><p class=\"mb:m md\">Mirrored</p>",
 		},
 		{
 			name: "imported from x and mirrored",
@@ -59,7 +59,7 @@ func TestStyle(t *testing.T) {
 				MirrorCode:    true,
 				MirrorPrivate: true,
 			},
-			expected: "<p class=\"mb:m md\">Imported from <code>x</code>,</p> <p class=\"mb:m md\">Mirrored.</p>",
+			expected: "<p class=\"mb:m md\">Imported from <code>x</code></p><p class=\"mb:m md\">Mirrored</p>",
 		},
 		{
 			name: "imported and mirrored from x",
@@ -69,7 +69,7 @@ func TestStyle(t *testing.T) {
 				MirrorURL:     "y",
 				MirrorCode:    true,
 			},
-			expected: "<p class=\"mb:m md\">Imported,</p> <p class=\"mb:m md\">Mirrored from <code>y</code>.</p>",
+			expected: "<p class=\"mb:m md\">Imported</p><p class=\"mb:m md\">Mirrored from <code>y</code></p>",
 		},
 		{
 			name: "imported from x and mirrored from x",
@@ -78,7 +78,7 @@ func TestStyle(t *testing.T) {
 				MirrorURL:  "y",
 				MirrorCode: true,
 			},
-			expected: "<p class=\"mb:m md\">Imported from <code>x</code>,</p> <p class=\"mb:m md\">Mirrored from <code>y</code>.</p>",
+			expected: "<p class=\"mb:m md\">Imported from <code>x</code></p><p class=\"mb:m md\">Mirrored from <code>y</code></p>",
 		},
 	}
 

--- a/modules/database/init/migrate.go
+++ b/modules/database/init/migrate.go
@@ -18,46 +18,13 @@ func runMigration(db *gorm.DB) {
 
 	// Wrap in a transaction to allow rollbacks.
 	db.Transaction(func(tx *gorm.DB) error {
-		tx.Exec("PRAGMA foreign_keys = OFF")
+		var s models.Style
 
-		var u models.User
-		var err error
-
-		if err = tx.Migrator().DropIndex(u, "idx_users_deleted_at"); err != nil {
-			log.Database.Fatalf("Failed to drop index for users: %s\n", err)
+		if err := tx.Migrator().AddColumn(s, "ImportPrivate"); err != nil {
+			log.Database.Fatalf("Failed to add column import_private: %s\n", err)
 		}
-
-		if err = tx.Migrator().RenameTable("users", "users_temp"); err != nil {
-			log.Database.Fatalf("Failed to rename table users: %s\n", err)
-		}
-
-		if err = tx.Migrator().CreateTable(u); err != nil {
-			log.Database.Fatalf("Failed to create table users: %s\n", err)
-		}
-
-		q := `INSERT INTO users SELECT id, created_at, updated_at, deleted_at, `
-		q += `username, email, o_auth_provider, password, biography, `
-		q += `display_name, role, last_login, last_password_reset, `
-		q += `authorized_o_auth, github, gitlab, codeberg FROM users_temp`
-		if err = tx.Exec(q).Error; err != nil {
-			log.Database.Fatalf("Failed to insert users: %s\n", err)
-		}
-
-		if err = tx.Migrator().DropTable("users_temp"); err != nil {
-			log.Database.Fatalf("Failed to drop users_temp table: %s\n", err)
-		}
-
-		// HACK: Fix up foreign key references in tables that have user_id.
-		if err = tx.Migrator().RenameTable("users", "users_temp"); err != nil {
-			log.Database.Fatalf("Failed to rename table users: %s\n", err)
-		}
-		if err = tx.Migrator().RenameTable("users_temp", "users"); err != nil {
-			log.Database.Fatalf("Failed to rename table users: %s\n", err)
-		}
-
-		var eu models.ExternalUser
-		if err = tx.AutoMigrate(&eu); err != nil {
-			log.Database.Fatalf("Failed to create external_users: %s\n", err)
+		if err := tx.Migrator().AddColumn(s, "MirrorPrivate"); err != nil {
+			log.Database.Fatalf("Failed to add column mirror_private: %s\n", err)
 		}
 
 		return nil

--- a/web/docs/endpoints.md
+++ b/web/docs/endpoints.md
@@ -89,6 +89,8 @@ Example response
         "Featured": true,
         "Category": "userstyles.world",
         "Original": "https://raw.githubusercontent.com/userstyles-world/tweaks/main/tweaks.user.styl",
+        "ImportPrivate": false,
+		"MirrorPrivate": false,
         "MirrorCode": true,
         "MirrorMeta": false,
         "UserID": 1,
@@ -112,7 +114,9 @@ Example response
         "MirrorCode": true,
         "MirrorMeta": false,
         "UserID": 1,
-        "Username": "vednoc"
+        "Username": "vednoc",
+        "ImportPrivate": false,
+		"MirrorPrivate": false
     }
 ]
 ```
@@ -143,7 +147,9 @@ Example response ID=29
     "MirrorCode": true,
     "MirrorMeta": false,
     "UserID": 11,
-    "Username": "Freeplay"
+    "Username": "Freeplay",
+    "ImportPrivate": false,
+	"MirrorPrivate": false
 }
 ```
 

--- a/web/views/style/edit.tmpl
+++ b/web/views/style/edit.tmpl
@@ -170,10 +170,13 @@
 		</div>
 	</div>
 
+
+	<p class="mb:s fg:3" id="privateURLs-hint">Check if you don't want these URLs to be shown on the style's page.</p>
+	
 	<!-- no reason to show this for styles which don't have import url -->
 	{{ if .Style.Original }}
 		<div class="ta:l">
-			<div class="checkbox iflex mb:m">
+			<div class="checkbox iflex">
 				<input type="checkbox" name="importPrivate"
 					id="importPrivate" aria-describedby="importPrivate-hint"
 					{{ if .Style.ImportPrivate }}checked{{ end }}>

--- a/web/views/style/edit.tmpl
+++ b/web/views/style/edit.tmpl
@@ -170,15 +170,19 @@
 		</div>
 	</div>
 
-	<div class="ta:l">
-		<div class="checkbox iflex mb:m">
-			<input type="checkbox" name="importPrivate"
-				id="importPrivate" aria-describedby="importPrivate-hint"
-				{{ if .Style.ImportPrivate }}checked{{ end }}>
-			{{ template "partials/checkboxes" }}
-			<label for="importPrivate">Keep import URL private</label>
+	<!-- no reason to show this for styles which don't have import url -->
+	{{ if .Style.Original }}
+		<div class="ta:l">
+			<div class="checkbox iflex mb:m">
+				<input type="checkbox" name="importPrivate"
+					id="importPrivate" aria-describedby="importPrivate-hint"
+					{{ if .Style.ImportPrivate }}checked{{ end }}>
+				{{ template "partials/checkboxes" }}
+				<label for="importPrivate">Keep import URL private</label>
+			</div>
 		</div>
-	</div>
+	{{ end }}
+
 	<div class="ta:l">
 		<div class="checkbox iflex mb:m">
 			<input type="checkbox" name="mirrorPrivate"

--- a/web/views/style/edit.tmpl
+++ b/web/views/style/edit.tmpl
@@ -170,6 +170,25 @@
 		</div>
 	</div>
 
+	<div class="ta:l">
+		<div class="checkbox iflex mb:m">
+			<input type="checkbox" name="importPrivate"
+				id="importPrivate" aria-describedby="importPrivate-hint"
+				{{ if .Style.ImportPrivate }}checked{{ end }}>
+			{{ template "partials/checkboxes" }}
+			<label for="importPrivate">Keep import URL private</label>
+		</div>
+	</div>
+	<div class="ta:l">
+		<div class="checkbox iflex mb:m">
+			<input type="checkbox" name="mirrorPrivate"
+				id="mirrorPrivate" aria-describedby="mirrorPrivate-hint"
+				{{ if .Style.MirrorPrivate }}checked{{ end }}>
+			{{ template "partials/checkboxes" }}
+			<label for="mirrorPrivate">Keep mirror URL private</label>
+		</div>
+	</div>
+
 	<button class="btn icon primary mt:m" type="submit">
 		{{ template "icons/save" }} Save changes
 	</button>

--- a/web/views/style/import.tmpl
+++ b/web/views/style/import.tmpl
@@ -201,6 +201,24 @@
 		</div>
 	{{ end }}
 
+	<div class="ta:l">
+		<div class="checkbox iflex mb:m">
+			<input type="checkbox" name="importPrivate"
+				id="importPrivate" aria-describedby="importPrivate-hint">
+			{{ template "partials/checkboxes" }}
+			<label for="importPrivate">Keep import URL private</label>
+		</div>
+	</div>
+
+	<div class="ta:l">
+		<div class="checkbox iflex mb:m">
+			<input type="checkbox" name="mirrorPrivate"
+				id="mirrorPrivate" aria-describedby="mirrorPrivate-hint">
+			{{ template "partials/checkboxes" }}
+			<label for="mirrorPrivate">Keep mirror URL private</label>
+		</div>
+	</div>
+
 	<button class="btn icon primary" type="submit">
 		{{ template "icons/save" }} Import userstyle
 	</button>

--- a/web/views/style/import.tmpl
+++ b/web/views/style/import.tmpl
@@ -204,6 +204,7 @@
 	<div class="ta:l">
 		<div class="checkbox iflex mb:m">
 			<input type="checkbox" name="importPrivate"
+				{{ if .Style.ImportPrivate }}checked{{ end }}
 				id="importPrivate" aria-describedby="importPrivate-hint">
 			{{ template "partials/checkboxes" }}
 			<label for="importPrivate">Keep import URL private</label>
@@ -213,6 +214,7 @@
 	<div class="ta:l">
 		<div class="checkbox iflex mb:m">
 			<input type="checkbox" name="mirrorPrivate"
+				{{ if .Style.MirrorPrivate }}checked{{ end }}
 				id="mirrorPrivate" aria-describedby="mirrorPrivate-hint">
 			{{ template "partials/checkboxes" }}
 			<label for="mirrorPrivate">Keep mirror URL private</label>

--- a/web/views/style/view.tmpl
+++ b/web/views/style/view.tmpl
@@ -7,18 +7,26 @@
 		<span class="fg:4"> by {{ .Style.Username }}</span>
 	</h1>
 
-	{{ if .Style.CompareMirrorURL }}
-		<p class="mb:m md">
-			Imported and mirrored from <code>{{ .Style.Original }}</code>
-		</p>
-	{{ else }}
-		{{ if .Style.Original }}
-			<p class="mb:m md">Imported{{ if .Style.ImportPrivate }} from <code>{{ .Style.Original }}</code>{{ end }}</p>
+	<p class="mb:m md">
+		<!-- There is wired distribuion across lines not to get spaces before punctuation marks. (Imported , Mirrored .) -->
+		{{ if and .Style.CompareMirrorURL (not (or .Style.ImportPrivate .Style.MirrorPrivate)) }}
+			Imported and mirrored from <code>{{ .Style.Original }}</code>.
+		{{ else if or .Style.ImportPrivate .Style.MirrorPrivate }}
+			{{ if .Style.Original }}
+				Imported{{ if not .Style.ImportPrivate }} from <code>{{ .Style.Original }}</code>{{ end }}{{ if and (or .Style.MirrorCode .Style.MirrorMeta) .Style.MirrorURL }},{{ else }}.{{ end }}
+			{{ end }}
+			{{ if and (or .Style.MirrorCode .Style.MirrorMeta) .Style.MirrorURL }}
+				Mirrored{{ if not .Style.MirrorPrivate }} from <code>{{ .Style.MirrorURL }}</code>{{ end }}.
+			{{ end }}
+		{{ else }}
+			{{ if .Style.Original }}
+				Imported from <code>{{ .Style.Original }}</code>{{ if and (or .Style.MirrorCode .Style.MirrorMeta) .Style.MirrorURL }},{{ else }}.{{ end }}
+			{{ end }}
+			{{ if and (or .Style.MirrorCode .Style.MirrorMeta) .Style.MirrorURL }}
+				Mirrored from <code>{{ .Style.MirrorURL }}</code>.
+			{{ end }}
 		{{ end }}
-		{{ if and (or .Style.MirrorCode .Style.MirrorMeta) .Style.MirrorURL }}
-			<p class="mb:m md">Mirrored{{ if .Style.MirrorPrivate }} from <code>{{ .Style.MirrorURL }}</code>{{ end }}</p>
-		{{ end }}
-	{{ end }}
+	</p>
 
 	<div class="card">
 		<div class="screenshot">

--- a/web/views/style/view.tmpl
+++ b/web/views/style/view.tmpl
@@ -7,20 +7,14 @@
 		<span class="fg:4"> by {{ .Style.Username }}</span>
 	</h1>
 
-	{{ if .Style.CompareMirrorURL }}
-		{{ with .Style.ImportedAndMirroredText }}
-			<p class="mb:m md">{{ unescape . }}</p>
-		{{ end }}
+	{{ if .Style.ImportedAndMirrored }}
+		<p class="mb:m md">{{ unescape .Style.ImportedAndMirroredText }}</p>
 	{{ else }}
-		{{ if .Style.ImportedCondition }}
-			{{ with .Style.ImportedText }}
-				<p class="mb:m md">{{ unescape . }}</p>
-			{{ end }}
+		{{ if .Style.Imported }}
+			<p class="mb:m md">{{ unescape .Style.ImportedText }}</p>
 		{{ end }}
-		{{ if .Style.MirroredCondition }}
-			{{ with .Style.MirroredText }}
-				<p class="mb:m md">{{ unescape . }}</p>
-			{{ end }}
+		{{ if .Style.Mirrored }}
+			<p class="mb:m md">{{ unescape .Style.MirroredText }}</p>
 		{{ end }}
 	{{ end }}
 

--- a/web/views/style/view.tmpl
+++ b/web/views/style/view.tmpl
@@ -13,10 +13,10 @@
 		</p>
 	{{ else }}
 		{{ if .Style.Original }}
-			<p class="mb:m md">Imported from <code>{{ .Style.Original }}</code></p>
+			<p class="mb:m md">Imported{{ if .Style.ImportPrivate }} from <code>{{ .Style.Original }}</code>{{ end }}</p>
 		{{ end }}
 		{{ if and (or .Style.MirrorCode .Style.MirrorMeta) .Style.MirrorURL }}
-			<p class="mb:m md">Mirrored from <code>{{ .Style.MirrorURL }}</code></p>
+			<p class="mb:m md">Mirrored{{ if .Style.MirrorPrivate }} from <code>{{ .Style.MirrorURL }}</code>{{ end }}</p>
 		{{ end }}
 	{{ end }}
 

--- a/web/views/style/view.tmpl
+++ b/web/views/style/view.tmpl
@@ -7,14 +7,14 @@
 		<span class="fg:4"> by {{ .Style.Username }}</span>
 	</h1>
 
-	{{ if .Style.ImportedAndMirrored }}
-		<p class="mb:m md">{{ unescape .Style.ImportedAndMirroredText }}</p>
+	{{ with .Style.ImportedAndMirrored }}
+		<p class="mb:m md">{{ unescape . }}</p>
 	{{ else }}
-		{{ if .Style.Imported }}
-			<p class="mb:m md">{{ unescape .Style.ImportedText }}</p>
+		{{ with .Style.Imported }}
+			<p class="mb:m md">{{ unescape . }}</p>
 		{{ end }}
-		{{ if .Style.Mirrored }}
-			<p class="mb:m md">{{ unescape .Style.MirroredText }}</p>
+		{{ with .Style.Mirrored }}
+			<p class="mb:m md">{{ unescape . }}</p>
 		{{ end }}
 	{{ end }}
 

--- a/web/views/style/view.tmpl
+++ b/web/views/style/view.tmpl
@@ -8,7 +8,7 @@
 	</h1>
 
 	{{ with .Style.HeadlineText }}
-		<p class="mb:m md">{{ unescape . }}</p>
+		{{ unescape . }}
 	{{ end }}
 
 	<div class="card">

--- a/web/views/style/view.tmpl
+++ b/web/views/style/view.tmpl
@@ -13,16 +13,16 @@
 			Imported and mirrored from <code>{{ .Style.Original }}</code>.
 		{{ else if or .Style.ImportPrivate .Style.MirrorPrivate }}
 			{{ if .Style.Original }}
-				Imported{{ if not .Style.ImportPrivate }} from <code>{{ .Style.Original }}</code>{{ end }}{{ if and (or .Style.MirrorCode .Style.MirrorMeta) .Style.MirrorURL }},{{ else }}.{{ end }}
+				Imported{{ if not .Style.ImportPrivate }} from <code>{{ .Style.Original }}</code>{{ end }}{{ if .Style.IsMirrored }},{{ else }}.{{ end }}
 			{{ end }}
-			{{ if and (or .Style.MirrorCode .Style.MirrorMeta) .Style.MirrorURL }}
+			{{ if .Style.IsMirrored }}
 				Mirrored{{ if not .Style.MirrorPrivate }} from <code>{{ .Style.MirrorURL }}</code>{{ end }}.
 			{{ end }}
 		{{ else }}
 			{{ if .Style.Original }}
-				Imported from <code>{{ .Style.Original }}</code>{{ if and (or .Style.MirrorCode .Style.MirrorMeta) .Style.MirrorURL }},{{ else }}.{{ end }}
+				Imported from <code>{{ .Style.Original }}</code>{{ if .Style.IsMirrored }},{{ else }}.{{ end }}
 			{{ end }}
-			{{ if and (or .Style.MirrorCode .Style.MirrorMeta) .Style.MirrorURL }}
+			{{ if .Style.IsMirrored }}
 				<nobr>Mirrored from <code>{{ .Style.MirrorURL }}</code>.</nobr>
 			{{ end }}
 		{{ end }}

--- a/web/views/style/view.tmpl
+++ b/web/views/style/view.tmpl
@@ -7,26 +7,9 @@
 		<span class="fg:4"> by {{ .Style.Username }}</span>
 	</h1>
 
-	<p class="mb:m md">
-		<!-- There is wired distribuion across lines not to get spaces before punctuation marks. (Imported , Mirrored .) -->
-		{{ if and .Style.CompareMirrorURL (not (or .Style.ImportPrivate .Style.MirrorPrivate)) }}
-			Imported and mirrored from <code>{{ .Style.Original }}</code>.
-		{{ else if or .Style.ImportPrivate .Style.MirrorPrivate }}
-			{{ if .Style.Original }}
-				Imported{{ if not .Style.ImportPrivate }} from <code>{{ .Style.Original }}</code>{{ end }}{{ if .Style.IsMirrored }},{{ else }}.{{ end }}
-			{{ end }}
-			{{ if .Style.IsMirrored }}
-				Mirrored{{ if not .Style.MirrorPrivate }} from <code>{{ .Style.MirrorURL }}</code>{{ end }}.
-			{{ end }}
-		{{ else }}
-			{{ if .Style.Original }}
-				Imported from <code>{{ .Style.Original }}</code>{{ if .Style.IsMirrored }},{{ else }}.{{ end }}
-			{{ end }}
-			{{ if .Style.IsMirrored }}
-				<nobr>Mirrored from <code>{{ .Style.MirrorURL }}</code>.</nobr>
-			{{ end }}
-		{{ end }}
-	</p>
+	{{ with .Style.HeadlineText }}
+		<p class="mb:m md">{{ unescape . }}</p>
+	{{ end }}
 
 	<div class="card">
 		<div class="screenshot">

--- a/web/views/style/view.tmpl
+++ b/web/views/style/view.tmpl
@@ -7,8 +7,21 @@
 		<span class="fg:4"> by {{ .Style.Username }}</span>
 	</h1>
 
-	{{ with .Style.HeadlineText }}
-		{{ unescape . }}
+	{{ if .Style.CompareMirrorURL }}
+		{{ with .Style.ImportedAndMirroredText }}
+			<p class="mb:m md">{{ unescape . }}</p>
+		{{ end }}
+	{{ else }}
+		{{ if .Style.ImportedCondition }}
+			{{ with .Style.ImportedText }}
+				<p class="mb:m md">{{ unescape . }}</p>
+			{{ end }}
+		{{ end }}
+		{{ if .Style.MirroredCondition }}
+			{{ with .Style.MirroredText }}
+				<p class="mb:m md">{{ unescape . }}</p>
+			{{ end }}
+		{{ end }}
 	{{ end }}
 
 	<div class="card">

--- a/web/views/style/view.tmpl
+++ b/web/views/style/view.tmpl
@@ -23,7 +23,7 @@
 				Imported from <code>{{ .Style.Original }}</code>{{ if and (or .Style.MirrorCode .Style.MirrorMeta) .Style.MirrorURL }},{{ else }}.{{ end }}
 			{{ end }}
 			{{ if and (or .Style.MirrorCode .Style.MirrorMeta) .Style.MirrorURL }}
-				Mirrored from <code>{{ .Style.MirrorURL }}</code>.
+				<nobr>Mirrored from <code>{{ .Style.MirrorURL }}</code>.</nobr>
 			{{ end }}
 		{{ end }}
 	</p>


### PR DESCRIPTION
This PR does what was purposed in #178.

Changes in style view:
- import and mirror URL are now on the same line. IMO it looks better and takes less space;
- this line now has punctuation marks;
- import and mirror URLs are now only shown when the style author want so.

Changes to styles:
- it is now possible to hide import or mirror URL in style editing or while importing;
- "Keep import URL private" is only shown for imported styles.