### PR TITLE
Improve Notes & Bio hints

### DIFF
--- a/web/views/oauth/settings.tmpl
+++ b/web/views/oauth/settings.tmpl
@@ -39,7 +39,7 @@
 			placeholder="e.g. UserCSS Manager">
 
 		<label for="description">Description</label>
-		<i class="fg:3" id="description-hint">Supports Markdown syntax.</i>
+		<i class="fg:3" id="description-hint">Supports {{ template "partials/markdown" . }} syntax.</i>
 		<textarea
 			required pattern="^[a-zA-Z0-9!@#$%-_ ]+$"
 			type="text" name="description" id="description"

--- a/web/views/partials/markdown.tmpl
+++ b/web/views/partials/markdown.tmpl
@@ -1,0 +1,1 @@
+<a href="https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet">Markdown</a>

--- a/web/views/style/add.tmpl
+++ b/web/views/style/add.tmpl
@@ -43,7 +43,7 @@
 	{{ with .err.Description }}<p class="danger" role="alert">{{ . }}</p>{{ end }}
 
 	<label for="notes">Notes</label>
-	<i class="fg:3" id="notes-hint">Long description of requirements, changelog, etc. Supports Markdown syntax.</i>
+	<i class="fg:3" id="notes-hint">Features, requirements, instructions, links, changelog, etc. Supports {{ template "partials/markdown" . }} syntax.</i>
 	<textarea
 		rows="3" class="shortTextarea"
 		type="text" name="notes" id="notes" maxlength="50000"

--- a/web/views/style/edit.tmpl
+++ b/web/views/style/edit.tmpl
@@ -38,7 +38,7 @@
 	{{ with .err.Description }}<p class="danger" role="alert">{{ . }}</p>{{ end }}
 
 	<label for="notes">Notes</label>
-	<i class="fg:3" id="notes-hint">Long description of requirements, changelog, etc. Supports Markdown syntax.</i>
+	<i class="fg:3" id="notes-hint">Features, requirements, instructions, links, changelog, etc. Supports {{ template "partials/markdown" . }} syntax.</i>
 	<textarea
 		rows="3" class="shortTextarea"
 		type="text" name="notes" id="notes" maxlength="50000"

--- a/web/views/style/import.tmpl
+++ b/web/views/style/import.tmpl
@@ -39,7 +39,7 @@
 		{{ with .err.Description }}<p class="danger" role="alert">{{ . }}</p>{{ end }}
 
 		<label for="notes">Notes</label>
-		<i class="fg:3" id="notes-hint">Long description of requirements, changelog, etc. Supports Markdown syntax.</i>
+		<i class="fg:3" id="notes-hint">Features, requirements, instructions, links, changelog, etc. Supports {{ template "partials/markdown" . }} syntax.</i>
 		<textarea
 			rows="3" class="shortTextarea"
 			type="text" name="notes" id="notes" maxlength="50000"

--- a/web/views/user/account.tmpl
+++ b/web/views/user/account.tmpl
@@ -119,7 +119,7 @@
 	<article class="md">{{ proxy (.Params.Biography | MarkdownUnsafe) "profile" .Params.ID | unescape }}</article>
 	<form class="Form Form-box mt:m" method="post" action="/account/bio">
 		<label for="biography">Set your biography</label>
-		<i class="fg:3" id="biography-hint">Supports Markdown syntax.</i>
+		<i class="fg:3" id="biography-hint">Supports {{ template "partials/markdown" . }} syntax.</i>
 		<textarea
 			type="text" name="bio" id="biography" maxlength="1000"
 			placeholder="e.g. I'd often make styles."


### PR DESCRIPTION
- better description for style Notes;
- add template for markdown cheatsheet link to simplify replacing the link later;
- add links to the cheatsheet to Notes and Bio.