### PR TITLE
Greet user in emails

### DIFF
--- a/handlers/user/register.go
+++ b/handlers/user/register.go
@@ -79,7 +79,7 @@ func RegisterPost(c *fiber.Ctx) error {
 			"You can safely ignore this e-mail if you never made an account for UserStyles.world.")
 	partHTML := utils.NewPart().
 		SetBody("Hi <p>" + u.Username + ",</p>\n" +
-			"<br>" +
+			"<br>\n" +
 			"<p>Verify your UserStyles.world account by clicking the link below.</p>\n" +
 			"<b>The link will expire in 2 hours</b>\n" +
 			"<br>\n" +

--- a/handlers/user/register.go
+++ b/handlers/user/register.go
@@ -72,12 +72,15 @@ func RegisterPost(c *fiber.Ctx) error {
 	link := c.BaseURL() + "/verify/" + utils.EncryptText(token, utils.AEADCrypto, config.ScrambleConfig)
 
 	partPlain := utils.NewPart().
-		SetBody("Verify your UserStyles.world account by clicking the link below.\n" +
+		SetBody("Hi " + u.Username + ",\n" +
+			"Verify your UserStyles.world account by clicking the link below.\n" +
 			"The link will expire in 2 hours\n\n" +
 			link + "\n\n" +
 			"You can safely ignore this e-mail if you never made an account for UserStyles.world.")
 	partHTML := utils.NewPart().
-		SetBody("<p>Verify your UserStyles.world account by clicking the link below.</p>\n" +
+		SetBody("Hi <p>" + u.Username + ",</p>\n" +
+			"<br>" +
+			"<p>Verify your UserStyles.world account by clicking the link below.</p>\n" +
 			"<b>The link will expire in 2 hours</b>\n" +
 			"<br>\n" +
 			"<a target=\"_blank\" clicktracking=\"off\" href=\"" + link + "\">Verifcation link</a>\n" +

--- a/handlers/user/reset.go
+++ b/handlers/user/reset.go
@@ -242,7 +242,7 @@ func RecoverPost(c *fiber.Ctx) error {
 			"You can safely ignore this e-mail if you didn't request to reset your password.")
 	partHTML := utils.NewPart().
 		SetBody("<p>Hi " + user.Username + ",</p>\n" +
-			"<br>" +
+			"<br>\n" +
 			"<p>We have received a request to reset the password for your UserStyles.world account.</p>\n" +
 			"<b>The link will expire in 2 hours</b>\n" +
 			"<br>\n" +

--- a/handlers/user/reset.go
+++ b/handlers/user/reset.go
@@ -235,12 +235,15 @@ func RecoverPost(c *fiber.Ctx) error {
 	link := c.BaseURL() + "/reset/" + utils.EncryptText(jwtToken, utils.AEADCrypto, config.ScrambleConfig)
 
 	partPlain := utils.NewPart().
-		SetBody("We have received a request to reset the password for your UserStyles.world account.\n\n" +
+		SetBody("Hi " + user.Username + ",\n" +
+			"We have received a request to reset the password for your UserStyles.world account.\n\n" +
 			"The link will expire in 2 hours\n\n" +
 			link + "\n\n" +
 			"You can safely ignore this e-mail if you didn't request to reset your password.")
 	partHTML := utils.NewPart().
-		SetBody("<p>We have received a request to reset the password for your UserStyles.world account.</p>\n" +
+		SetBody("<p>Hi " + user.Username + ",</p>\n" +
+			"<br>" +
+			"<p>We have received a request to reset the password for your UserStyles.world account.</p>\n" +
 			"<b>The link will expire in 2 hours</b>\n" +
 			"<br>\n" +
 			"<a target=\"_blank\" clicktracking=\"off\" href=\"" + link + "\">Reset password link</a>\n" +


### PR DESCRIPTION
Greetings reduce the chances of users forgetting their usernames and generally make emails better.  In some emails we were already greeting users, in some not. This PR improves consistency.
I'm not sure how `\n` works in `partHTML`.