### PR TITLE
Improve account page

### DIFF
--- a/web/scss/ui/_utils.scss
+++ b/web/scss/ui/_utils.scss
@@ -114,6 +114,8 @@
 .minw {
     display: inline-flex;
     min-width: 15ex;
+    align-items: center;
+    gap: 0.25rem;
 }
 .td\:d { text-decoration: underline }
 [hidden] { display: none !important }

--- a/web/views/user/account.tmpl
+++ b/web/views/user/account.tmpl
@@ -11,7 +11,7 @@
 		really helpful! If you're a userstyle author,
 		don't hesitate to reach out and let us know what
 		you'd like to see on this platform. You can do so
-		via <a href="{{ config "appSourceCode" }}">GitHub</a>
+		via <a href="{{ config "appSourceCode" }}/issues">GitHub</a>
 		or via <a href="mailto:feedback@userstyles.world">email</a>.
 	</p>
 	{{ end }}

--- a/web/views/user/account.tmpl
+++ b/web/views/user/account.tmpl
@@ -21,12 +21,24 @@
 	<h2 class="td:d">Details</h2>
 	<p><span class="minw">ID</span>{{ .Params.ID }}</p>
 	<p><span class="minw">Role</span>{{ .Params.RoleString }}</p>
-	<p><span class="minw">Username</span>{{ .Params.Username }}</p>
+	<p>
+		<span class="minw">Username
+			<label data-tooltip="Contact admins to change">
+				{{ template "icons/info" }}
+			</label>
+		</span>{{ .Params.Username }}
+	</p>
 	{{ with .Params.DisplayName }}
 		<p><span class="minw">Display name</span>{{ . }}</p>
 	{{ end }}
 	{{ with .Params.Email }}
-		<p><span class="minw">Email</span>{{ . }}</p>
+		<p>
+			<span class="minw">Email
+				<label data-tooltip="Contact admins to change">
+					{{ template "icons/info" }}
+				</label>
+			</span>{{ . }}
+		</p>
 	{{ end }}
 	<p class="joined flex">
 		<span class="minw">Joined</span>


### PR DESCRIPTION
- link directly to repo issues for feedback, so users are less likely to get lost when they open the link;
- add `(i)` icons with tooltips for fields that require contacting administrators to change, so users don't try to change the username by deleting the account. (#224)