### PR TITLE
Style sharing updates

### DIFF
--- a/handlers/style/view.go
+++ b/handlers/style/view.go
@@ -50,7 +50,7 @@ func GetStylePage(c *fiber.Ctx) error {
 		"User":       u,
 		"Title":      data.Name,
 		"Style":      data,
-		"URL":        c.BaseURL() + c.Path(),
+		"URL":        c.BaseURL() + "/style/" + id,
 		"Slug":       slug,
 		"Canonical":  "style/" + id + "/" + slug,
 		"RenderMeta": true,

--- a/web/typescript/page/view-style.ts
+++ b/web/typescript/page/view-style.ts
@@ -11,6 +11,7 @@ function shareButton() {
     if (!shareButton) {
         return;
     }
+    shareButton.removeAttribute("hidden");
     shareButton.addEventListener('click', () => {
         navigator.clipboard.writeText(urlValue).then(() => {
             shareButton.classList.add('copied');

--- a/web/typescript/page/view-style.ts
+++ b/web/typescript/page/view-style.ts
@@ -3,6 +3,7 @@ import {doDomOperation} from 'utils/dom';
 export const initViewStyle = () => doDomOperation(() => {
     shareButton();
     checkIfStyleInstalled();
+    removeStylusTooltip();
 });
 
 function shareButton() {
@@ -46,4 +47,9 @@ function checkIfStyleInstalled() {
         data: {type: 'usw-style-info-request', requestType: 'installed', styleID},
         origin: 'https://userstyles.world'
     }));
+}
+
+function removeStylusTooltip() {
+    const Stylus = document.querySelector('a#stylus');
+    Stylus.removeAttribute("data-tooltip");
 }

--- a/web/typescript/page/view-style.ts
+++ b/web/typescript/page/view-style.ts
@@ -6,14 +6,15 @@ export const initViewStyle = () => doDomOperation(() => {
 });
 
 function shareButton() {
-    const urlValue = document.getElementById('share').textContent;
+    const urlBar = document.getElementById('share');
     const shareButton = document.getElementById('btn-share') as HTMLButtonElement;
     if (!shareButton) {
         return;
     }
+    urlBar.textContent += urlBar.getAttribute("slug");
     shareButton.removeAttribute("hidden");
     shareButton.addEventListener('click', () => {
-        navigator.clipboard.writeText(urlValue).then(() => {
+        navigator.clipboard.writeText(urlBar.textContent).then(() => {
             shareButton.classList.add('copied');
         }, () => {
             shareButton.classList.add('copied-failed');

--- a/web/views/style/view.tmpl
+++ b/web/views/style/view.tmpl
@@ -50,7 +50,7 @@
 		<button
 			aria-label="Copy Style URL to clipboard"
 			data-tooltip="Style URL has been copied to your clipboard."
-			id="btn-share" class="btn icon iflex ai:c">
+			id="btn-share" class="btn icon iflex ai:c" hidden>
 			{{ template "icons/copy" }} Copy
 		</button>
 	</div>

--- a/web/views/style/view.tmpl
+++ b/web/views/style/view.tmpl
@@ -133,6 +133,7 @@
 			target="_blank"
 			rel="noopener"
 			href="https://github.com/openstyles/stylus/#readme"
+			data-tooltip="Stylus detection only works with JS enabled"
 			id="stylus" class="btn icon stylus"
 		>{{ template "icons/brush" }} Get Stylus</a>
 	</div>

--- a/web/views/style/view.tmpl
+++ b/web/views/style/view.tmpl
@@ -46,7 +46,7 @@
 
 <section class="header flex mt:m ai:c">
 	<div class="share flex ai:c mr:m">
-		<span id="share" class="bg:2 input-like">{{ .URL }}</span>
+		<span id="share" class="bg:2 input-like" slug="/{{ .Slug }}">{{ .URL }}</span>
 		<button
 			aria-label="Copy Style URL to clipboard"
 			data-tooltip="Style URL has been copied to your clipboard."


### PR DESCRIPTION
- [x] don't display copy button for nojs;
- [x] don't display slug for nojs to avoid link truncation;
- [ ] ~~add support for [native sharing](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share).~~ It's not worth it atm;
- [x] unrelated but near here: add hint about Stylus button for nojs.