### PR TITLE
Increase flags expiration time

### DIFF
--- a/handlers/user/account.go
+++ b/handlers/user/account.go
@@ -175,7 +175,7 @@ func EditAccount(c *fiber.Ctx) error {
 			Name:     "flags",
 			Value:    v,
 			Path:     "/",
-			Expires:  time.Now().Add(time.Hour * 24 * 30),
+			Expires:  time.Now().Add(time.Hour * 24 * 30 * 6),
 			Secure:   config.Production,
 			HTTPOnly: true,
 			SameSite: fiber.CookieSameSiteLaxMode,


### PR DESCRIPTION
They reset annoyingly often. This PR increases the time from 30 days to 180.
This is now less consistent with login cookie, which uses `24 * 31 * 3`, but i think 30 is better than 31.