### PR TITLE
docs: update faq entry about stylus inline search

### DIFF
--- a/web/docs/faq.md
+++ b/web/docs/faq.md
@@ -1,6 +1,6 @@
 ---
 Title: Frequently Asked Questions
-UpdatedAt: 2023-10-07T15:00:00+02:00
+UpdatedAt: 2024-05-25T16:53:00+02:00
 ---
 
 <!-- markdown-toc start - Don't edit this section. -->
@@ -73,7 +73,11 @@ Because of how inline search works, it may take up to 15 minutes for your style
 to show up or get metadata updated.
 
 Make sure that you have set the category for your style properly. It may be the
-name of the service or a domain name (with subdomain part included).
+name of the service or a domain name. If the domain TLD is either .org or .com,
+you must omit it. If the TLD is something else, you must indicate both the domain
+and the TLD.
+
+The subdomain part must also be included.
 
 
 ### Why are ratings different in Stylus' search?


### PR DESCRIPTION
## Why?

I published a style on userstyles.world a few days ago. But it was still not appearing in stylus inline search. I found the FAQ but it was only mentioning that the category had to be present (which was the case) and mention the subdomain (no subdomain in my case).

After waiting a bit more, trying to understand what was wrong, I piggybacked on a stylus issue (see https://github.com/openstyles/stylus/issues/1777) and understood that for .com and .org domains, the TLD had to be omitted, an information I could find nowhere.

## What?

- doc: complete the `faq.md` page and explain this org/com TLD thing. 

Of course feel free to suggest better wording if you have anything, or tell me if you want to incorporate more details in this section.