### PR TITLE
Update air package location

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -19,8 +19,8 @@ It's unlikely that you'll need to build them from scratch, but it's possible.
 ### Install Go
 
 Our codebase uses the [Go](https://go.dev/) programming language. With Go
-installed, you will need to install [air](https://github.com/cosmtrek/air) by
-running `go install github.com/cosmtrek/air@latest` if you want to use `run
+installed, you will need to install [air](https://github.com/air-verse/air) by
+running `go install github.com/air-verse/air@latest` if you want to use `run
 watch` command.
 
 ### Install Sass

--- a/tools/run
+++ b/tools/run
@@ -21,7 +21,7 @@ took() {
 check() {
     hint() {
         case "$1" in
-            air) printf "Install it with 'go install github.com/cosmtrek/air@latest'.\n" ;;
+            air) printf "Install it with 'go install github.com/air-verse/air@latest'.\n" ;;
             [bd]c) printf "Install 'bc' with your package manager.\n" ;;
             go) printf "Install 'go' with your package manager.\n" ;;
             git) printf "Install 'git' with your package manager.\n" ;;


### PR DESCRIPTION
It was [moved](https://github.com/air-verse/air/issues/599) to an org. The redirect can be experienced in live on GitHub: https://github.com/cosmtrek/air.

Tested.